### PR TITLE
feat(history): singing history page with expandable play entries

### DIFF
--- a/.agents/skills/using-tailwind/SKILL.md
+++ b/.agents/skills/using-tailwind/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: using-tailwind
+description: 'Guidelines for styling UI in this project — when to use TWC (react-twc) vs inline Tailwind classes, and which AKUI primitives to reach for. Use when building or reviewing UI components.'
+---
+
+# Tailwind & Component Styling
+
+## TWC (react-twc) usage
+
+Use `twc` only when the component:
+
+- Will be **used multiple times** (appears at 2+ call sites in the codebase), **and/or**
+- Has **complex conditional classes** (multiple ifs in `className`)
+
+Otherwise **inline** the element with a plain `className`.
+
+```tsx
+// ✅ TWC — appears at multiple call sites
+const DateHeader = twc(Typography)`mt-6 mb-2 text-lg font-semibold opacity-70`;
+
+// ✅ TWC — conditional classes via callback
+const Card = twc.div((props: { 'data-focused'?: boolean }) => [
+  'cursor-pointer rounded-lg px-6 py-4 transition-transform',
+  props['data-focused'] && 'bg-active scale-[1.025]',
+]);
+
+// ✅ Inline — one-off wrapper, no conditionals
+<div className="flex h-full flex-col gap-2 overflow-y-auto p-8">
+
+// ✅ Inline with Typography — one-off heading
+<Typography as="h1" className="mb-4 text-3xl font-bold">History</Typography>
+```
+
+## AKUI Primitives
+
+Prefer components from `src/modules/Elements/AKUI/` over raw HTML + classes:
+
+- **`Typography`** (`~/modules/Elements/AKUI/Primitives/Typography`) — for any text. Accepts `as` for element type (`h1`, `h2`, `p`, `div`…). Adds the `typography` CSS class automatically. Supports `active` prop for accent colour.
+- **`Box`** (`~/modules/Elements/AKUI/Primitives/Box`) — polymorphic container with `flex flex-col items-center justify-center rounded-md bg-black/50`. Override with `className`. Not suitable where those defaults are unwanted.
+- **`Menu` / `Menu.Button` / `Menu.Header`** — for menu screens (main menu, settings).
+- Use `twc(Typography)` or `twc(Box)` to create reusable AKUI-based TWC variants.

--- a/.agents/skills/writing-e2e-tests/SKILL.md
+++ b/.agents/skills/writing-e2e-tests/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: writing-e2e-tests
+description: 'Patterns and guidelines for writing Playwright E2E tests in this project — page object rules, assertion placement, and locator conventions. Use when writing new tests or reviewing existing ones.'
+---
+
+# Writing E2E Tests
+
+## Locators belong in page objects
+
+`.spec.ts` files must never locate elements directly — all locators must be exposed via a page object:
+
+```ts
+// ✅ Locator defined on the page object, used in spec
+await expect(pages.historyPage.container).toBeVisible();
+
+// ❌ Locating elements directly in a spec file
+await expect(page.getByTestId('history-page')).toBeVisible();
+await expect(page.locator('.some-class')).toBeVisible();
+```
+
+## Where to put assertions
+
+- **Simple assertions** (e.g. visibility, count) belong in the `.spec.ts` test directly.
+- **Assertions that touch implementation details** (e.g. checking an attribute value, computed style) or contain non-trivial logic should be encapsulated as a method on the page object.
+
+```ts
+// ✅ Simple visibility check — in spec
+await expect(pages.historyPage.emptyState).toBeVisible();
+
+// ✅ Complex / implementation-detail assertion — on page object
+// PageObject:
+public async expectEntryCount(count: number) {
+  await expect(this.entries).toHaveCount(count);
+}
+// Spec:
+await pages.historyPage.expectEntryCount(3);
+```
+
+## Assertions
+
+Use `expect(locator).toBeVisible()` instead of `locator.waitFor()`:
+
+```ts
+// ✅
+await expect(pages.historyPage.container).toBeVisible();
+await expect(this.entries).toHaveCount(count);
+
+// ❌
+await pages.historyPage.container.waitFor();
+await this.entries.nth(count - 1).waitFor();
+```
+
+Import `expect` from `@playwright/test` in page objects that use it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Agent Instructions
-* The baseline branch is called `master` (not `main`, not `trunk` etc)
-* This project uses React Compiler and thus callbacks and values don't need to be manually memoized
+
+- The baseline branch is called `master` (not `main`, not `trunk` etc)
+- This project uses React Compiler and thus callbacks and values don't need to be manually memoized
 
 ## Commands
 

--- a/context.md
+++ b/context.md
@@ -1,0 +1,89 @@
+# AllKaraoke Glossary
+
+Last updated: 2026-05-16
+
+## Singing and Scoring
+
+- **frequency** — Player voice in Hz, sampled continuously from the input source.
+- **frequencyRecord** — A single frequency sample paired with the song timestamp when it was captured.
+- **pitch** — Musical note as a number (0 = C0). Derived from frequency.
+- **distance** — Semitones between player pitch and target pitch, ignoring octave. A tolerance margin can make small distances count as zero.
+- **tolerance** — Allowed pitch error window; configured per sing setup.
+- **playerNote** — Group of consecutive `frequencyRecord`s matched (by time and distance) to a song note. Represents the coloured sung lines visible in-game.
+- **vibrato** — Pitch oscillation detected on a `playerNote`, contributing a bonus.
+- **perfect** — Hit accuracy category used in the detailed score breakdown.
+
+## Song Data Structure
+
+A song is a hierarchy: **Song → tracks → sections → notes**.
+
+- **Song** — Full parsed karaoke object. Contains metadata (artist, title, video, BPM, gap…), the array of `SongTrack`s, and a pre-computed `mergedTrack`.
+- **SongPreview** — Lightweight version of `Song` used in song list screens (no full note data).
+- **track** (`SongTrack`) — One vocal lane of a song. Duet songs have two named tracks. Each track holds an ordered array of `Section`s and a `changes` array marking where the active singer alternates.
+- **mergedTrack** — Synthesised track combining all tracks; used when player count or mode does not map 1-to-1 to tracks (e.g. single-player on a duet song).
+- **section** — A segment within a track. Either a `NotesSection` (has singable notes) or a `PauseSection` (instrumental break). Each section carries a `start` beat position.
+- **note** — One singable syllable within a `NotesSection`. Has `start` (beat), `length` (beats), `pitch`, `lyrics` text, and a `type`.
+- **songBeat** — Beat-based time unit used for all note/section positioning. Converted to milliseconds via BPM and song gap. `songBeat = 0` is the chart origin before the gap offset.
+- **gap** — Millisecond offset applied to align the chart start with actual audio/video playback.
+- **videoGap** — Additional offset between the start of the video and the moment singing begins.
+- **BPM** — Beats per minute as declared in the UltraStar source file, used to compute beat-to-ms conversion.
+- **realBpm** — Actual musical tempo when the UltraStar BPM value has been doubled/halved for technical reasons.
+
+### Note types
+
+- **normal (`:`)** — Standard scorable note.
+- **star (`*`)** — Golden note; grants bonus points.
+- **rap (`R`)** — Judged as hit on any detected singing; reduced points.
+- **freestyle (`F`)** — Same hit logic as rap; reduced points.
+- **rapstar (`G`)** — Golden rap note variant.
+
+## Input Management
+
+Input is managed through two cooperating singletons:
+
+- **InputSourceListManager** (`src/routes/SelectInput/InputSources/index.ts`) — Maintains the available hardware/virtual input list per source type. Notifies the rest of the app via `inputListChanged` when the device list changes (e.g. a remote mic connects). Input source types: `Microphone`, `Remote Microphone`, `Dummy`.
+- **InputManager** (`src/modules/GameEngine/Input/InputManager.ts`) — Per-player facade used during gameplay. Reads from whichever source type the player's `SelectedPlayerInput` points to (resolved through `PlayersManager`). Handles `startMonitoring` / `stopMonitoring` and exposes per-player `frequency`, `volume`, and `inputLag`.
+- **SelectedPlayerInput** — Struct `{ source, deviceId, channel }` stored per player that identifies exactly which input to read from.
+- **channel** — Index into a multi-channel device (e.g. SingStar mic has channels 0 and 1 for the two colours).
+- **input lag** — Per-player configurable delay (ms) applied when mapping a frequency timestamp to a song beat, compensating for device latency.
+- **Dummy input** — Silent virtual input used in development/tests instead of a real microphone.
+- **DrawingTest input** — Internal test-only input simulating singing via a drawing gesture; not available in production builds.
+
+## Songs, Library, and Content
+
+- **UltraStar .txt** — Source karaoke format parsed by this app.
+- **Convert** — Import flow for turning a UltraStar TXT file into a playable song.
+- **built-in song** — Song shipped with the main library.
+- **local song** — Song stored in the user's own browser.
+- **setlist** — Curated named list of songs (by `shortId`) that can be shared via link. Can be editable (users may add songs during selection) or locked.
+- **excluded languages** — Per-user language filter; songs in excluded languages are hidden from the song selection screen.
+- **jukebox** — Non-scoring song playback mode.
+
+## Remote Microphone and Networking
+
+- **host** — The main game browser session that runs the game and owns the room.
+- **remote mic** — A phone/secondary browser acting as microphone input, connected to the host over a network transport.
+- **room ID** — Identifier used to pair a remote mic with its host session; prefix determines transport type (`k` = PartyKit, `w` = WebSocket).
+- **remote keyboard** — Navigation control surface on the remote mic screen for operating host menus.
+- **remote song list** — Delta-based personal favourites list sent from a remote mic to the host.
+- **remote mic permissions** — Access level granted to a remote client: `write` (full control) or `read` (limited).
+- **readiness confirmation** — Step before a song starts where each remote mic confirms it is ready (required on iOS after a page reload to enable microphone access).
+- **PartyKit** — Default transport backend for remote mics (Cloudflare Workers based).
+- **WebSockets** — Alternative direct WebSocket transport for remote mics.
+- **PeerJS** — Legacy peer-to-peer WebRTC transport, kept for backwards compatibility.
+
+## App Routes
+
+- **Quick Setup** — First-run microphone setup wizard.
+- **Select Input** — Assign inputs/microphones to player slots.
+- **Manage Songs** — Administer local songs, import, and access setlist editing.
+- **Convert** — Import and sync a UltraStar TXT song with a video.
+- **Edit Setlists** — Create and manage named setlists.
+- **Exclude Languages** — Configure per-user language filter.
+- **Settings** — Global settings including remote mic options and calibration.
+- **Jukebox** — Playback-only song browsing.
+
+## Deprecated / Legacy
+
+- **Remotion** — Video generation subsystem, deprecated and not to be used.
+- **Emotion / css-in-js** — Legacy styling approach; Tailwind CSS is preferred for new code.

--- a/docs/plans/2026-05-19-singing-history-design.md
+++ b/docs/plans/2026-05-19-singing-history-design.md
@@ -35,9 +35,9 @@ If a song has since been removed from the library, the entry still appears with 
 ```typescript
 interface PlayHistoryEntry {
   songKey: string;
-  song: SongPreview | null;       // null = song removed from library
-  date: string;                   // ISO timestamp
-  progress: number | undefined;   // 0–1 completion
+  song: SongPreview | null; // null = song removed from library
+  date: string; // ISO timestamp
+  progress: number | undefined; // 0–1 completion
   mode: GAME_MODE;
   scores: Array<{ name: string; score: number }>;
 }
@@ -67,11 +67,11 @@ This matches the existing storage format — no transformation needed.
 
 All in `src/routes/History/`:
 
-| File | Responsibility |
-|------|---------------|
-| `HistoryPage.tsx` | Main page, calls `usePlayHistory()`, renders date groups |
+| File                | Responsibility                                             |
+| ------------------- | ---------------------------------------------------------- |
+| `HistoryPage.tsx`   | Main page, calls `usePlayHistory()`, renders date groups   |
 | `PlayEntryCard.tsx` | Single expandable card; click/Enter toggles expanded state |
-| `usePlayHistory.ts` | Data hook — flatten, sort, group by day |
+| `usePlayHistory.ts` | Data hook — flatten, sort, group by day                    |
 
 Styling uses existing AKUI components (Tailwind, consistent with the rest of the app).
 

--- a/docs/plans/2026-05-19-singing-history.md
+++ b/docs/plans/2026-05-19-singing-history.md
@@ -13,6 +13,7 @@
 ### Task 1: Add route path
 
 **Files:**
+
 - Modify: `src/routes/routePaths.ts`
 
 **Step 1: Add the HISTORY route key**
@@ -26,7 +27,7 @@ const routePaths = {
   GAME: 'game',
   MENU: 'menu',
   JUKEBOX: 'jukebox',
-  HISTORY: 'history',           // ← add this
+  HISTORY: 'history', // ← add this
   SELECT_INPUT: 'select-input',
   // ... rest unchanged
 } as const;
@@ -44,6 +45,7 @@ git commit -m "feat(history): add HISTORY route path"
 ### Task 2: Write a failing E2E navigation test
 
 **Files:**
+
 - Create: `tests/PageObjects/HistoryPage.ts`
 - Create: `tests/history.spec.ts`
 
@@ -154,6 +156,7 @@ git commit -m "test(history): add failing E2E test for history page navigation"
 ### Task 3: Register the route in App.tsx and add menu button
 
 **Files:**
+
 - Modify: `src/App.tsx`
 - Modify: `src/routes/Welcome/Welcome.tsx`
 
@@ -234,6 +237,7 @@ git commit -m "feat(history): add route, menu button, and page stub"
 ### Task 4: Implement `usePlayHistory` hook
 
 **Files:**
+
 - Create: `src/routes/History/usePlayHistory.ts`
 
 **Step 1: Write a unit test for the data transformation logic**
@@ -389,17 +393,20 @@ git commit -m "feat(history): add usePlayHistory data hook with unit tests"
 ### Task 5: Implement `PlayEntryCard` component
 
 **Files:**
+
 - Create: `src/routes/History/PlayEntryCard.tsx`
 
 **Step 1: Understand how scores are displayed**
 
 The `scores` array in a `PlayHistoryEntry` already has the right shape for display:
+
 - In co-op mode it has one entry like `{ name: "Alex, Sam", score: 1240000 }`
 - In duel/duet mode it has one entry per player
 
 Score numbers should be formatted with `toLocaleString()` (e.g. `1,240,000`).
 
 Game mode should be rendered as human-readable text:
+
 - `DUEL` → "Duel"
 - `CO_OP` → "Co-op"
 - `PASS_THE_MIC` → "Pass the Mic"
@@ -470,16 +477,12 @@ export function PlayEntryCard({ entry, isExpanded, focused, onClick, ...rest }: 
   );
 }
 
-const Card = twc.div`
-  cursor-pointer rounded-lg px-6 py-4
-  data-[focused=true]:bg-active data-[focused=true]:scale-[1.025]
-  transition-transform
-`;
+const Card = twc.div`data-[focused=true]:bg-active cursor-pointer rounded-lg px-6 py-4 transition-transform data-[focused=true]:scale-[1.025]`;
 const CollapsedRow = twc.div`flex items-center justify-between gap-4`;
 const SongInfo = twc.div`flex flex-col`;
 const Title = twc.span`typography font-bold`;
 const Artist = twc.span`typography text-sm opacity-70`;
-const Time = twc.span`typography text-sm opacity-70 shrink-0`;
+const Time = twc.span`typography shrink-0 text-sm opacity-70`;
 const Details = twc.div`mt-3 flex flex-col gap-1 border-t border-white/20 pt-3`;
 const DetailRow = twc.div`typography flex justify-between text-sm`;
 ```
@@ -498,6 +501,7 @@ git commit -m "feat(history): add PlayEntryCard expandable component"
 ### Task 6: Implement `HistoryPage` component
 
 **Files:**
+
 - Modify: `src/routes/History/HistoryPage.tsx`
 
 **Step 1: Look at a settings page for layout reference**
@@ -538,9 +542,7 @@ function HistoryPage() {
       <Container data-test="history-page">
         <Header>History</Header>
         {loading && <Message>Loading…</Message>}
-        {isEmpty && (
-          <Message data-test="history-empty-state">No songs sung yet — go sing something!</Message>
-        )}
+        {isEmpty && <Message data-test="history-empty-state">No songs sung yet — go sing something!</Message>}
         {groups.map((group) => (
           <section key={group.label}>
             <DateHeader>{group.label}</DateHeader>
@@ -555,9 +557,7 @@ function HistoryPage() {
                   entry={entry}
                   isExpanded={isExpanded}
                   data-test="history-entry"
-                  {...register(entryKey, () =>
-                    setExpandedKey(isExpanded ? null : entryKey),
-                  )}
+                  {...register(entryKey, () => setExpandedKey(isExpanded ? null : entryKey))}
                 />
               );
             })}
@@ -568,9 +568,9 @@ function HistoryPage() {
   );
 }
 
-const Container = twc.div`flex flex-col gap-2 overflow-y-auto p-8 h-full`;
-const Header = twc.h1`typography text-3xl font-bold mb-4`;
-const DateHeader = twc.h2`typography text-lg font-semibold opacity-70 mt-6 mb-2 first:mt-0`;
+const Container = twc.div`flex h-full flex-col gap-2 overflow-y-auto p-8`;
+const Header = twc.h1`typography mb-4 text-3xl font-bold`;
+const DateHeader = twc.h2`typography mt-6 mb-2 text-lg font-semibold opacity-70 first:mt-0`;
 const Message = twc.p`typography opacity-70`;
 
 export default HistoryPage;
@@ -596,6 +596,7 @@ git commit -m "feat(history): implement history page with date groups and keyboa
 ### Task 7: E2E test — entry appears after singing
 
 **Files:**
+
 - Modify: `tests/history.spec.ts`
 
 **Step 1: Add a test that sings a song and checks history**
@@ -673,21 +674,21 @@ git commit -m "fix(history): resolve type and lint issues"
 
 ## Summary of new files
 
-| File | Purpose |
-|------|---------|
-| `src/routes/History/HistoryPage.tsx` | Main page component |
-| `src/routes/History/PlayEntryCard.tsx` | Expandable song play card |
-| `src/routes/History/usePlayHistory.ts` | Data hook (load, flatten, group) |
-| `src/routes/History/usePlayHistory.test.ts` | Unit tests for grouping logic |
-| `tests/PageObjects/HistoryPage.ts` | Page object for E2E tests |
-| `tests/history.spec.ts` | E2E tests |
+| File                                        | Purpose                          |
+| ------------------------------------------- | -------------------------------- |
+| `src/routes/History/HistoryPage.tsx`        | Main page component              |
+| `src/routes/History/PlayEntryCard.tsx`      | Expandable song play card        |
+| `src/routes/History/usePlayHistory.ts`      | Data hook (load, flatten, group) |
+| `src/routes/History/usePlayHistory.test.ts` | Unit tests for grouping logic    |
+| `tests/PageObjects/HistoryPage.ts`          | Page object for E2E tests        |
+| `tests/history.spec.ts`                     | E2E tests                        |
 
 ## Modified files
 
-| File | Change |
-|------|--------|
-| `src/routes/routePaths.ts` | Add `HISTORY: 'history'` |
-| `src/App.tsx` | Register lazy-loaded `HistoryPage` route |
-| `src/routes/Welcome/Welcome.tsx` | Add History menu button |
-| `tests/PageObjects/initialise.ts` | Register `historyPage` page object |
-| `tests/PageObjects/MainMenuPage.ts` | Add `goToHistory()` method |
+| File                                | Change                                   |
+| ----------------------------------- | ---------------------------------------- |
+| `src/routes/routePaths.ts`          | Add `HISTORY: 'history'`                 |
+| `src/App.tsx`                       | Register lazy-loaded `HistoryPage` route |
+| `src/routes/Welcome/Welcome.tsx`    | Add History menu button                  |
+| `tests/PageObjects/initialise.ts`   | Register `historyPage` page object       |
+| `tests/PageObjects/MainMenuPage.ts` | Add `goToHistory()` method               |

--- a/docs/plans/2026-05-19-singing-history.md
+++ b/docs/plans/2026-05-19-singing-history.md
@@ -1,0 +1,693 @@
+# Singing History Page Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a "History" page accessible from the main menu that shows all songs sung on this device as a date-grouped, chronological feed with expandable entries.
+
+**Architecture:** Play history is already stored in LocalForage per song via `SongStats`. A new `usePlayHistory` hook loads all stats and the song index, flattens them into a sorted list of `PlayHistoryEntry` objects, and groups them by calendar day. The `HistoryPage` renders date headers and expandable `PlayEntryCard` components with standard `useKeyboardNav` vertical navigation.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS (react-twc), wouter (routing), LocalForage (existing stats storage), dayjs (date formatting), react-use `useAsync` (async data loading), `useKeyboardNav` (keyboard navigation)
+
+---
+
+### Task 1: Add route path
+
+**Files:**
+- Modify: `src/routes/routePaths.ts`
+
+**Step 1: Add the HISTORY route key**
+
+In `src/routes/routePaths.ts`, add `HISTORY: 'history'` to the `routePaths` object (e.g. after `JUKEBOX`):
+
+```typescript
+const routePaths = {
+  INDEX: '',
+  QUICK_SETUP: 'quick-setup',
+  GAME: 'game',
+  MENU: 'menu',
+  JUKEBOX: 'jukebox',
+  HISTORY: 'history',           // ← add this
+  SELECT_INPUT: 'select-input',
+  // ... rest unchanged
+} as const;
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/routes/routePaths.ts
+git commit -m "feat(history): add HISTORY route path"
+```
+
+---
+
+### Task 2: Write a failing E2E navigation test
+
+**Files:**
+- Create: `tests/PageObjects/HistoryPage.ts`
+- Create: `tests/history.spec.ts`
+
+**Step 1: Read the e2e-playwright skill to understand the project's test conventions**
+
+Read file: `.agents/skills/e2e-playwright/SKILL.md`
+
+**Step 2: Create the page object**
+
+Create `tests/PageObjects/HistoryPage.ts`:
+
+```typescript
+import { Page } from '@playwright/test';
+
+export class HistoryPage {
+  constructor(private readonly page: Page) {}
+
+  public get container() {
+    return this.page.getByTestId('history-page');
+  }
+
+  public get emptyState() {
+    return this.page.getByTestId('history-empty-state');
+  }
+
+  public get entries() {
+    return this.page.getByTestId('history-entry');
+  }
+
+  public async expectEntryCount(count: number) {
+    await this.entries.nth(count - 1).waitFor();
+    const actual = await this.entries.count();
+    if (actual !== count) throw new Error(`Expected ${count} entries, got ${actual}`);
+  }
+
+  public async navigateToEntry(index: number) {
+    // Move keyboard focus to this entry (0-based index from top)
+    for (let i = 0; i < index; i++) {
+      await this.page.keyboard.press('ArrowDown');
+    }
+  }
+
+  public async expandFocusedEntry() {
+    await this.page.keyboard.press('Enter');
+  }
+
+  public get expandedDetails() {
+    return this.page.getByTestId('history-entry-details');
+  }
+}
+```
+
+**Step 3: Look at tests/PageObjects/initialise.ts to understand how to register the new page object**
+
+Open and read `tests/PageObjects/initialise.ts` — find how other page objects like `jukeboxPage` are registered, then add `historyPage` in the same pattern.
+
+**Step 4: Create the test file**
+
+Create `tests/history.spec.ts`:
+
+```typescript
+import { expect, test } from '@playwright/test';
+import initialise from './PageObjects/initialise';
+import { initTestMode, mockSongs } from './helpers';
+
+let pages: ReturnType<typeof initialise>;
+test.beforeEach(async ({ page, context, browser }) => {
+  pages = initialise(page, context, browser);
+  await initTestMode({ page, context });
+  await mockSongs({ page, context });
+});
+
+test('History page', async ({ page }) => {
+  await page.goto('/?e2e-test');
+
+  await test.step('Navigate from main menu to History', async () => {
+    await pages.landingPage.enterTheGame();
+    await pages.mainMenuPage.goToHistory();
+    await pages.historyPage.container.waitFor();
+  });
+
+  await test.step('Shows empty state when no songs have been sung', async () => {
+    await pages.historyPage.emptyState.waitFor();
+  });
+
+  await test.step('Back to menu via backspace', async () => {
+    await page.keyboard.press('Backspace');
+    await pages.mainMenuPage.waitForContainer();
+  });
+});
+```
+
+**Step 5: Run the test — expect it to fail**
+
+Check the e2e-playwright skill for the exact command to run a single test file. It will fail because `goToHistory()` does not exist yet on the main menu page object, and the History page does not exist.
+
+Expected output: test failure mentioning missing navigation or page not found.
+
+**Step 6: Commit the failing test**
+
+```bash
+git add tests/PageObjects/HistoryPage.ts tests/history.spec.ts tests/PageObjects/initialise.ts
+git commit -m "test(history): add failing E2E test for history page navigation"
+```
+
+---
+
+### Task 3: Register the route in App.tsx and add menu button
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/routes/Welcome/Welcome.tsx`
+
+**Step 1: Add the route to App.tsx**
+
+In `src/App.tsx`, import `History` lazily (same pattern as `LazySongList`):
+
+```typescript
+const LazyHistory = lazy(() => import('~/routes/History/HistoryPage'));
+```
+
+Then add the route inside `<Switch>`, alongside the other routes (e.g. after the JUKEBOX route):
+
+```tsx
+<Route
+  path={routePaths.HISTORY}
+  component={() => (
+    <Suspense fallback={<PageLoader />}>
+      <LazyHistory />
+    </Suspense>
+  )}
+/>
+```
+
+**Step 2: Add the History button to Welcome.tsx**
+
+In `src/routes/Welcome/Welcome.tsx`, add a new `SmoothLink` + `Menu.Button` entry. Place it after the "Jukebox" button and before "Manage Songs":
+
+```tsx
+<SmoothLink to="history/">
+  <Menu.Button {...register('history', () => navigate('history/'))}>History</Menu.Button>
+</SmoothLink>
+```
+
+**Step 3: Add `goToHistory()` to the main menu page object**
+
+Open `tests/PageObjects/MainMenuPage.ts` (or equivalent). Find the existing navigation methods (e.g. `goToJukebox()`). Add:
+
+```typescript
+public async goToHistory() {
+  await this.page.getByTestId('history').click();
+}
+```
+
+The `data-test` attribute value `'history'` is automatically set by `register('history', ...)` in `useKeyboardNav`.
+
+**Step 4: Also add `waitForContainer()` to MainMenuPage if it doesn't exist**
+
+If the main menu page object doesn't have a `waitForContainer()` method, add one that waits for a known element on the menu page (e.g. the "Sing a song" button).
+
+**Step 5: Create a minimal HistoryPage stub so the route resolves**
+
+Create `src/routes/History/HistoryPage.tsx` with a placeholder:
+
+```tsx
+function HistoryPage() {
+  return <div data-test="history-page">History</div>;
+}
+
+export default HistoryPage;
+```
+
+**Step 6: Run the E2E test — expect steps 1 and 3 to pass, step 2 (empty state) to fail**
+
+Check the e2e-playwright skill for the exact command.
+
+Expected: navigation works, but `history-empty-state` element is not found.
+
+**Step 7: Commit**
+
+```bash
+git add src/App.tsx src/routes/Welcome/Welcome.tsx src/routes/History/HistoryPage.tsx tests/PageObjects/MainMenuPage.ts
+git commit -m "feat(history): add route, menu button, and page stub"
+```
+
+---
+
+### Task 4: Implement `usePlayHistory` hook
+
+**Files:**
+- Create: `src/routes/History/usePlayHistory.ts`
+
+**Step 1: Write a unit test for the data transformation logic**
+
+Create `src/routes/History/usePlayHistory.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { groupEntriesByDay } from './usePlayHistory';
+
+describe('groupEntriesByDay', () => {
+  it('groups entries from the same calendar day under one header', () => {
+    const entries = [
+      { date: '2026-05-19T21:00:00.000Z', songKey: 'a', song: null, progress: 1, mode: 'DUEL', scores: [] },
+      { date: '2026-05-19T20:00:00.000Z', songKey: 'b', song: null, progress: 1, mode: 'DUEL', scores: [] },
+      { date: '2026-05-18T20:00:00.000Z', songKey: 'c', song: null, progress: 1, mode: 'DUEL', scores: [] },
+    ] as any;
+
+    const groups = groupEntriesByDay(entries);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].entries).toHaveLength(2);
+    expect(groups[1].entries).toHaveLength(1);
+  });
+
+  it('returns empty array for no entries', () => {
+    expect(groupEntriesByDay([])).toEqual([]);
+  });
+});
+```
+
+**Step 2: Run the unit test — expect it to fail**
+
+```bash
+pnpm test src/routes/History/usePlayHistory.test.ts
+```
+
+Expected: FAIL — `groupEntriesByDay is not exported`
+
+**Step 3: Implement `usePlayHistory.ts`**
+
+Create `src/routes/History/usePlayHistory.ts`:
+
+```typescript
+import dayjs from 'dayjs';
+import { useAsync } from 'react-use';
+import { SingSetup, SongPreview } from '~/interfaces';
+import SongsService from '~/modules/Songs/SongsService';
+import { getAllStats, getSongKey } from '~/modules/Songs/stats/common';
+
+export interface PlayHistoryEntry {
+  songKey: string;
+  // null when the song has been removed from the library
+  song: SongPreview | null;
+  date: string;
+  progress: number | undefined;
+  mode: SingSetup['mode'];
+  scores: Array<{ name: string; score: number }>;
+}
+
+export interface PlayHistoryGroup {
+  // Human-readable label: "Today", "Yesterday", or "18 May 2026"
+  label: string;
+  entries: PlayHistoryEntry[];
+}
+
+export function groupEntriesByDay(entries: PlayHistoryEntry[]): PlayHistoryGroup[] {
+  const groups: PlayHistoryGroup[] = [];
+  let currentDayKey = '';
+  let currentGroup: PlayHistoryGroup | null = null;
+
+  const today = dayjs();
+
+  for (const entry of entries) {
+    const entryDay = dayjs(entry.date);
+    const dayKey = entryDay.format('YYYY-MM-DD');
+
+    if (dayKey !== currentDayKey) {
+      currentDayKey = dayKey;
+
+      let label: string;
+      if (entryDay.isSame(today, 'day')) {
+        label = 'Today';
+      } else if (entryDay.isSame(today.subtract(1, 'day'), 'day')) {
+        label = 'Yesterday';
+      } else {
+        label = entryDay.format('D MMMM YYYY');
+      }
+
+      currentGroup = { label, entries: [] };
+      groups.push(currentGroup);
+    }
+
+    currentGroup!.entries.push(entry);
+  }
+
+  return groups;
+}
+
+export function usePlayHistory(): { groups: PlayHistoryGroup[]; loading: boolean } {
+  const statsAsync = useAsync(() => getAllStats(), []);
+  const songIndexAsync = useAsync(() => SongsService.getIndex(), []);
+
+  if (statsAsync.loading || songIndexAsync.loading || !statsAsync.value || !songIndexAsync.value) {
+    return { groups: [], loading: true };
+  }
+
+  // Build hash → SongPreview lookup map
+  const songsByKey = new Map<string, SongPreview>();
+  for (const song of songIndexAsync.value) {
+    songsByKey.set(getSongKey(song), song);
+  }
+
+  // Flatten all score entries across all songs
+  const flatEntries: PlayHistoryEntry[] = [];
+  for (const [key, stats] of Object.entries(statsAsync.value)) {
+    const song = songsByKey.get(key) ?? null;
+    for (const scoreEntry of stats.scores) {
+      flatEntries.push({
+        songKey: key,
+        song,
+        date: scoreEntry.date,
+        progress: scoreEntry.progress,
+        mode: scoreEntry.setup.mode,
+        scores: scoreEntry.scores,
+      });
+    }
+  }
+
+  // Sort newest first
+  flatEntries.sort((a, b) => b.date.localeCompare(a.date));
+
+  return { groups: groupEntriesByDay(flatEntries), loading: false };
+}
+```
+
+**Step 4: Run the unit test — expect it to pass**
+
+```bash
+pnpm test src/routes/History/usePlayHistory.test.ts
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/routes/History/usePlayHistory.ts src/routes/History/usePlayHistory.test.ts
+git commit -m "feat(history): add usePlayHistory data hook with unit tests"
+```
+
+---
+
+### Task 5: Implement `PlayEntryCard` component
+
+**Files:**
+- Create: `src/routes/History/PlayEntryCard.tsx`
+
+**Step 1: Understand how scores are displayed**
+
+The `scores` array in a `PlayHistoryEntry` already has the right shape for display:
+- In co-op mode it has one entry like `{ name: "Alex, Sam", score: 1240000 }`
+- In duel/duet mode it has one entry per player
+
+Score numbers should be formatted with `toLocaleString()` (e.g. `1,240,000`).
+
+Game mode should be rendered as human-readable text:
+- `DUEL` → "Duel"
+- `CO_OP` → "Co-op"
+- `PASS_THE_MIC` → "Pass the Mic"
+
+Completion: `progress` is a 0–1 float — display as percentage (e.g. `Math.round(progress * 100) + '%'`). If `progress` is undefined, omit it.
+
+**Step 2: Implement `PlayEntryCard.tsx`**
+
+`PlayEntryCard` receives the spread result of `register(...)` as additional props, plus the entry data. The `focused` prop is provided by the register spread:
+
+```tsx
+import { twc } from 'react-twc';
+import dayjs from 'dayjs';
+import { GAME_MODE } from '~/interfaces';
+import { PlayHistoryEntry } from './usePlayHistory';
+
+const GAME_MODE_LABELS: Record<string, string> = {
+  [GAME_MODE.DUEL]: 'Duel',
+  [GAME_MODE.CO_OP]: 'Co-op',
+  [GAME_MODE.PASS_THE_MIC]: 'Pass the Mic',
+};
+
+interface Props {
+  entry: PlayHistoryEntry;
+  isExpanded: boolean;
+  focused: boolean;
+  onClick: () => void;
+  'data-test': string;
+  'data-focused': boolean;
+}
+
+export function PlayEntryCard({ entry, isExpanded, focused, onClick, ...rest }: Props) {
+  const songTitle = entry.song ? entry.song.title : 'Deleted song';
+  const songArtist = entry.song ? entry.song.artist : '';
+  const time = dayjs(entry.date).format('h:mm A');
+
+  return (
+    <Card data-focused={focused} onClick={onClick} {...rest}>
+      <CollapsedRow>
+        <SongInfo>
+          <Title>{songTitle}</Title>
+          {songArtist && <Artist>{songArtist}</Artist>}
+        </SongInfo>
+        <Time>{time}</Time>
+      </CollapsedRow>
+
+      {isExpanded && (
+        <Details data-test="history-entry-details">
+          <DetailRow>
+            <span>Mode</span>
+            <span>{GAME_MODE_LABELS[entry.mode] ?? entry.mode}</span>
+          </DetailRow>
+          {entry.progress !== undefined && (
+            <DetailRow>
+              <span>Completion</span>
+              <span>{Math.round(entry.progress * 100)}%</span>
+            </DetailRow>
+          )}
+          {entry.scores.map((score) => (
+            <DetailRow key={score.name}>
+              <span>{score.name}</span>
+              <span>{score.score.toLocaleString()}</span>
+            </DetailRow>
+          ))}
+        </Details>
+      )}
+    </Card>
+  );
+}
+
+const Card = twc.div`
+  cursor-pointer rounded-lg px-6 py-4
+  data-[focused=true]:bg-active data-[focused=true]:scale-[1.025]
+  transition-transform
+`;
+const CollapsedRow = twc.div`flex items-center justify-between gap-4`;
+const SongInfo = twc.div`flex flex-col`;
+const Title = twc.span`typography font-bold`;
+const Artist = twc.span`typography text-sm opacity-70`;
+const Time = twc.span`typography text-sm opacity-70 shrink-0`;
+const Details = twc.div`mt-3 flex flex-col gap-1 border-t border-white/20 pt-3`;
+const DetailRow = twc.div`typography flex justify-between text-sm`;
+```
+
+> Note: `data-[focused=true]:bg-active` is the Tailwind pattern used in other AKUI components for focus state. Check the Button component (`src/modules/Elements/AKUI/Button.tsx`) to confirm the exact class names used and align styling.
+
+**Step 3: Commit**
+
+```bash
+git add src/routes/History/PlayEntryCard.tsx
+git commit -m "feat(history): add PlayEntryCard expandable component"
+```
+
+---
+
+### Task 6: Implement `HistoryPage` component
+
+**Files:**
+- Modify: `src/routes/History/HistoryPage.tsx`
+
+**Step 1: Look at a settings page for layout reference**
+
+Open `src/routes/Settings/RemoteMicSettings.tsx` to see how a non-game page uses `useKeyboardNav` + `onBackspace` + a back button. Use it as a structural reference for `HistoryPage`.
+
+Also open `src/routes/Welcome/Welcome.tsx` to see how `MenuWithLogo` wraps a vertical list — consider whether to use `MenuWithLogo` or a custom layout. For a scrollable history list (potentially many items), a custom layout inside `LayoutGame` is more appropriate.
+
+**Step 2: Implement `HistoryPage.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { twc } from 'react-twc';
+import { useBackground } from '~/modules/Elements/BackgroundContext';
+import useKeyboardNav from '~/modules/hooks/useKeyboardNav';
+import useSmoothNavigate from '~/modules/hooks/useSmoothNavigate';
+import LayoutGame from '~/routes/LayoutGame';
+import { PlayEntryCard } from './PlayEntryCard';
+import { usePlayHistory } from './usePlayHistory';
+
+function HistoryPage() {
+  useBackground(true);
+  const navigate = useSmoothNavigate();
+  const { groups, loading } = usePlayHistory();
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  const { register } = useKeyboardNav({ onBackspace: () => navigate('menu/') });
+
+  const allEntries = groups.flatMap((group) => group.entries);
+  const isEmpty = !loading && allEntries.length === 0;
+
+  return (
+    <LayoutGame>
+      <Helmet>
+        <title>History | AllKaraoke.Party</title>
+      </Helmet>
+      <Container data-test="history-page">
+        <Header>History</Header>
+        {loading && <Message>Loading…</Message>}
+        {isEmpty && (
+          <Message data-test="history-empty-state">No songs sung yet — go sing something!</Message>
+        )}
+        {groups.map((group) => (
+          <section key={group.label}>
+            <DateHeader>{group.label}</DateHeader>
+            {group.entries.map((entry) => {
+              // Unique key per play: song hash + timestamp
+              const entryKey = `${entry.songKey}-${entry.date}`;
+              const isExpanded = expandedKey === entryKey;
+
+              return (
+                <PlayEntryCard
+                  key={entryKey}
+                  entry={entry}
+                  isExpanded={isExpanded}
+                  data-test="history-entry"
+                  {...register(entryKey, () =>
+                    setExpandedKey(isExpanded ? null : entryKey),
+                  )}
+                />
+              );
+            })}
+          </section>
+        ))}
+      </Container>
+    </LayoutGame>
+  );
+}
+
+const Container = twc.div`flex flex-col gap-2 overflow-y-auto p-8 h-full`;
+const Header = twc.h1`typography text-3xl font-bold mb-4`;
+const DateHeader = twc.h2`typography text-lg font-semibold opacity-70 mt-6 mb-2 first:mt-0`;
+const Message = twc.p`typography opacity-70`;
+
+export default HistoryPage;
+```
+
+> Note: Check what props `LayoutGame` accepts (open `src/routes/LayoutGame.tsx`). If it doesn't fit a scrollable list, use an alternative wrapper — look at how `ManageSongs` or `Settings` lay out their content.
+
+**Step 3: Run the E2E test — all steps should now pass**
+
+Check the e2e-playwright skill for the exact command to run `tests/history.spec.ts`.
+
+Expected: all steps PASS (navigate to page, see empty state, backspace to menu).
+
+**Step 4: Commit**
+
+```bash
+git add src/routes/History/HistoryPage.tsx
+git commit -m "feat(history): implement history page with date groups and keyboard nav"
+```
+
+---
+
+### Task 7: E2E test — entry appears after singing
+
+**Files:**
+- Modify: `tests/history.spec.ts`
+
+**Step 1: Add a test that sings a song and checks history**
+
+This test needs to complete a full song (or at least get a non-zero score) and then navigate to the history page to verify the entry appears.
+
+Look at `tests/sing-a-song.spec.ts` (or similar) to understand how `pages.singASong` flow works — specifically how to start and finish a song quickly in test mode.
+
+Add to `tests/history.spec.ts`:
+
+```typescript
+test('History entry appears after singing a song', async ({ page }) => {
+  await page.goto('/?e2e-test');
+
+  await test.step('Sing a song', async () => {
+    await pages.landingPage.enterTheGame();
+    // Use existing page objects to pick a song and complete it
+    // Look at sing-a-song.spec.ts for the exact steps
+  });
+
+  await test.step('Navigate to History', async () => {
+    await pages.mainMenuPage.goToHistory();
+    await pages.historyPage.container.waitFor();
+  });
+
+  await test.step('The sung song appears in the history', async () => {
+    await pages.historyPage.expectEntryCount(1);
+  });
+});
+```
+
+> **Note:** Fill in the "Sing a song" step by studying `tests/sing-a-song.spec.ts`. You need to reach the post-game screen so the `songEnded` event fires and stats are stored. Look for a `finishSong` or `skipToEnd` helper in the page objects.
+
+**Step 2: Run the test**
+
+Check the e2e-playwright skill for the exact command.
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/history.spec.ts
+git commit -m "test(history): add E2E test for entry appearing after singing"
+```
+
+---
+
+### Task 8: Type-check and lint
+
+**Step 1: Run type checking**
+
+```bash
+pnpm type-check
+```
+
+Fix any TypeScript errors before proceeding.
+
+**Step 2: Run linting**
+
+```bash
+pnpm lint
+```
+
+Fix any lint errors.
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(history): resolve type and lint issues"
+```
+
+---
+
+## Summary of new files
+
+| File | Purpose |
+|------|---------|
+| `src/routes/History/HistoryPage.tsx` | Main page component |
+| `src/routes/History/PlayEntryCard.tsx` | Expandable song play card |
+| `src/routes/History/usePlayHistory.ts` | Data hook (load, flatten, group) |
+| `src/routes/History/usePlayHistory.test.ts` | Unit tests for grouping logic |
+| `tests/PageObjects/HistoryPage.ts` | Page object for E2E tests |
+| `tests/history.spec.ts` | E2E tests |
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `src/routes/routePaths.ts` | Add `HISTORY: 'history'` |
+| `src/App.tsx` | Register lazy-loaded `HistoryPage` route |
+| `src/routes/Welcome/Welcome.tsx` | Add History menu button |
+| `tests/PageObjects/initialise.ts` | Register `historyPage` page object |
+| `tests/PageObjects/MainMenuPage.ts` | Add `goToHistory()` method |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import Welcome from '~/routes/Welcome/Welcome';
 const LazySongList = lazy(() =>
   import('~/routes/ManageSongs/SongManagement').then((modules) => ({ default: modules.SongList })),
 );
+const LazyHistory = lazy(() => import('~/routes/History/HistoryPage'));
 const LazySetlist = lazy(() => import('~/routes/Edit/Setlists').then((modules) => ({ default: modules.default })));
 
 // Commenting this out as there are many failed to fetch errors coming from Googlebot
@@ -61,6 +62,14 @@ function App() {
                 <Route path={routePaths.MENU} component={Welcome} />
                 <Route path={routePaths.EXCLUDE_LANGUAGES} component={ExcludeLanguages} />
                 <Route path={routePaths.JUKEBOX} component={Jukebox} />
+                <Route
+                  path={routePaths.HISTORY}
+                  component={() => (
+                    <Suspense fallback={<PageLoader />}>
+                      <LazyHistory />
+                    </Suspense>
+                  )}
+                />
                 <Route path={routePaths.GAME}>
                   {/*<Suspense fallback={<PageLoader />}><LazyGame /></Suspense>*/}
                   <Game />

--- a/src/modules/Elements/AKUI/Menu.tsx
+++ b/src/modules/Elements/AKUI/Menu.tsx
@@ -33,5 +33,5 @@ Menu.ButtonGroup = twc.div`flex`;
 Menu.HelpText = MenuHelpText;
 Menu.SubHeader = MenuSubHeader;
 Menu.Divider = ({ className, ...props }: ComponentProps<'hr'>) => (
-  <hr className={`border-white/20 ${className}`} {...props} />
+  <hr className={['border-white/20', className].filter(Boolean).join(' ')} {...props} />
 );

--- a/src/modules/Elements/AKUI/Menu.tsx
+++ b/src/modules/Elements/AKUI/Menu.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps, PropsWithChildren, ReactNode } from 'react';
+import { ComponentProps, HTMLProps, PropsWithChildren, ReactNode } from 'react';
 import { twc } from 'react-twc';
 import { MenuButton } from '~/modules/Elements/AKUI/Menu/MenuButton';
 import Box from '~/modules/Elements/AKUI/Primitives/Box';
@@ -32,4 +32,6 @@ Menu.Button = MenuButton;
 Menu.ButtonGroup = twc.div`flex`;
 Menu.HelpText = MenuHelpText;
 Menu.SubHeader = MenuSubHeader;
-Menu.Divider = () => <hr />;
+Menu.Divider = ({ className, ...props }: ComponentProps<'hr'>) => (
+  <hr className={`border-white/20 ${className}`} {...props} />
+);

--- a/src/routes/History/HistoryPage.tsx
+++ b/src/routes/History/HistoryPage.tsx
@@ -1,0 +1,5 @@
+function HistoryPage() {
+  return <div data-test="history-page">History</div>;
+}
+
+export default HistoryPage;

--- a/src/routes/History/HistoryPage.tsx
+++ b/src/routes/History/HistoryPage.tsx
@@ -1,15 +1,13 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { twc } from 'react-twc';
-import { useBackground } from '~/modules/Elements/BackgroundContext';
+import { Menu } from '~/modules/Elements/AKUI/Menu';
+import MenuWithLogo from '~/modules/Elements/MenuWithLogo';
 import useKeyboardNav from '~/modules/hooks/useKeyboardNav';
 import useSmoothNavigate from '~/modules/hooks/useSmoothNavigate';
-import LayoutGame from '~/routes/LayoutGame';
 import { PlayEntryCard } from './PlayEntryCard';
 import { usePlayHistory } from './usePlayHistory';
 
 function HistoryPage() {
-  useBackground(true);
   const navigate = useSmoothNavigate();
   const { groups, loading } = usePlayHistory();
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
@@ -19,42 +17,37 @@ function HistoryPage() {
   const isEmpty = !loading && groups.length === 0;
 
   return (
-    <LayoutGame>
+    <MenuWithLogo data-test="history-page">
       <Helmet>
         <title>History | AllKaraoke.Party</title>
       </Helmet>
-      <Container data-test="history-page">
-        <Header>History</Header>
-        {loading && <Message>Loading…</Message>}
-        {isEmpty && <Message data-test="history-empty-state">No songs sung yet — go sing something!</Message>}
-        {groups.map((group) => (
-          <section key={group.label}>
-            <DateHeader>{group.label}</DateHeader>
-            {group.entries.map((entry) => {
-              // Unique key per play: song hash + ISO timestamp
-              const entryKey = `${entry.songKey}-${entry.date}`;
-              const isExpanded = expandedKey === entryKey;
+      <Menu.Header>History</Menu.Header>
+      {loading && <Menu.HelpText>Loading…</Menu.HelpText>}
+      {isEmpty && <Menu.HelpText data-test="history-empty-state">No songs sung yet — go sing something!</Menu.HelpText>}
+      {groups.map((group) => (
+        <Fragment key={group.label}>
+          <Menu.SubHeader>{group.label}</Menu.SubHeader>
+          {group.entries.map((entry) => {
+            // Unique key per play: song hash + ISO timestamp
+            const entryKey = `${entry.songKey}-${entry.date}`;
+            const isExpanded = expandedKey === entryKey;
 
-              return (
-                <PlayEntryCard
-                  key={entryKey}
-                  entry={entry}
-                  isExpanded={isExpanded}
-                  data-test="history-entry"
-                  {...register(entryKey, () => setExpandedKey(isExpanded ? null : entryKey))}
-                />
-              );
-            })}
-          </section>
-        ))}
-      </Container>
-    </LayoutGame>
+            return (
+              <PlayEntryCard
+                key={entryKey}
+                entry={entry}
+                isExpanded={isExpanded}
+                {...register(entryKey, () => setExpandedKey(isExpanded ? null : entryKey))}
+                data-test="history-entry"
+              />
+            );
+          })}
+        </Fragment>
+      ))}
+      <Menu.Divider />
+      <Menu.Button {...register('back', () => navigate('menu/'))}>Back</Menu.Button>
+    </MenuWithLogo>
   );
 }
-
-const Container = twc.div`flex h-full flex-col gap-2 overflow-y-auto p-8`;
-const Header = twc.h1`typography mb-4 text-3xl font-bold`;
-const DateHeader = twc.h2`typography mt-6 mb-2 text-lg font-semibold opacity-70 first:mt-0`;
-const Message = twc.p`typography opacity-70`;
 
 export default HistoryPage;

--- a/src/routes/History/HistoryPage.tsx
+++ b/src/routes/History/HistoryPage.tsx
@@ -1,5 +1,60 @@
+import { useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { twc } from 'react-twc';
+import { useBackground } from '~/modules/Elements/BackgroundContext';
+import useKeyboardNav from '~/modules/hooks/useKeyboardNav';
+import useSmoothNavigate from '~/modules/hooks/useSmoothNavigate';
+import LayoutGame from '~/routes/LayoutGame';
+import { PlayEntryCard } from './PlayEntryCard';
+import { usePlayHistory } from './usePlayHistory';
+
 function HistoryPage() {
-  return <div data-test="history-page">History</div>;
+  useBackground(true);
+  const navigate = useSmoothNavigate();
+  const { groups, loading } = usePlayHistory();
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  const { register } = useKeyboardNav({ onBackspace: () => navigate('menu/') });
+
+  const isEmpty = !loading && groups.length === 0;
+
+  return (
+    <LayoutGame>
+      <Helmet>
+        <title>History | AllKaraoke.Party</title>
+      </Helmet>
+      <Container data-test="history-page">
+        <Header>History</Header>
+        {loading && <Message>Loading…</Message>}
+        {isEmpty && <Message data-test="history-empty-state">No songs sung yet — go sing something!</Message>}
+        {groups.map((group) => (
+          <section key={group.label}>
+            <DateHeader>{group.label}</DateHeader>
+            {group.entries.map((entry) => {
+              // Unique key per play: song hash + ISO timestamp
+              const entryKey = `${entry.songKey}-${entry.date}`;
+              const isExpanded = expandedKey === entryKey;
+
+              return (
+                <PlayEntryCard
+                  key={entryKey}
+                  entry={entry}
+                  isExpanded={isExpanded}
+                  data-test="history-entry"
+                  {...register(entryKey, () => setExpandedKey(isExpanded ? null : entryKey))}
+                />
+              );
+            })}
+          </section>
+        ))}
+      </Container>
+    </LayoutGame>
+  );
 }
+
+const Container = twc.div`flex h-full flex-col gap-2 overflow-y-auto p-8`;
+const Header = twc.h1`typography mb-4 text-3xl font-bold`;
+const DateHeader = twc.h2`typography mt-6 mb-2 text-lg font-semibold opacity-70 first:mt-0`;
+const Message = twc.p`typography opacity-70`;
 
 export default HistoryPage;

--- a/src/routes/History/PlayEntryCard.tsx
+++ b/src/routes/History/PlayEntryCard.tsx
@@ -1,0 +1,76 @@
+import dayjs from 'dayjs';
+import { twc } from 'react-twc';
+import { GAME_MODE } from '~/interfaces';
+import isE2E from '~/modules/utils/isE2E';
+import { cn } from '~/utils/cn';
+import { PlayHistoryEntry } from './usePlayHistory';
+
+const GAME_MODE_LABELS: Record<string, string> = {
+  [GAME_MODE.DUEL]: 'Duel',
+  [GAME_MODE.CO_OP]: 'Co-op',
+  [GAME_MODE.PASS_THE_MIC]: 'Pass the Mic',
+};
+
+interface Props {
+  entry: PlayHistoryEntry;
+  isExpanded: boolean;
+  // Props from useKeyboardNav register() spread
+  focused?: boolean;
+  onClick?: () => void;
+  'data-test'?: string;
+  // Destructured separately to prevent double-spreading onto Card
+  'data-focused'?: boolean;
+}
+
+export function PlayEntryCard({ entry, isExpanded, focused, onClick, 'data-focused': _dataFocused, ...rest }: Props) {
+  const songTitle = entry.song ? entry.song.title : 'Deleted song';
+  const songArtist = entry.song ? entry.song.artist : '';
+  const time = dayjs(entry.date).format('h:mm A');
+
+  return (
+    <Card
+      data-focused={focused}
+      // Mirrors the focus state logic used in ButtonBase (src/modules/Elements/AKUI/Button.tsx)
+      className={cn(!isE2E() && focused && 'bg-active scale-[1.025]')}
+      onClick={onClick}
+      {...rest}>
+      <CollapsedRow>
+        <SongInfo>
+          <Title>{songTitle}</Title>
+          {songArtist && <Artist>{songArtist}</Artist>}
+        </SongInfo>
+        <Time>{time}</Time>
+      </CollapsedRow>
+
+      {isExpanded && (
+        <Details data-test="history-entry-details">
+          <DetailRow>
+            <span>Mode</span>
+            <span>{GAME_MODE_LABELS[entry.mode] ?? entry.mode}</span>
+          </DetailRow>
+          {entry.progress !== undefined && (
+            <DetailRow>
+              <span>Completion</span>
+              <span>{Math.round(entry.progress * 100)}%</span>
+            </DetailRow>
+          )}
+          {entry.scores.map((score) => (
+            <DetailRow key={score.name}>
+              <span>{score.name}</span>
+              <span>{score.score.toLocaleString()}</span>
+            </DetailRow>
+          ))}
+        </Details>
+      )}
+    </Card>
+  );
+}
+
+const Card = twc.div`cursor-pointer rounded-lg px-6 py-4 transition-transform`;
+const CollapsedRow = twc.div`flex items-center justify-between gap-4`;
+const SongInfo = twc.div`flex flex-col`;
+const Title = twc.span`typography font-bold`;
+const Artist = twc.span`typography text-sm opacity-70`;
+const Time = twc.span`typography shrink-0 text-sm opacity-70`;
+const Details = twc.div`mt-3 flex flex-col gap-1 border-t border-white/20 pt-3`;
+const DetailRow = twc.div`typography flex justify-between text-sm`;

--- a/src/routes/History/PlayEntryCard.tsx
+++ b/src/routes/History/PlayEntryCard.tsx
@@ -1,8 +1,9 @@
 import dayjs from 'dayjs';
 import { twc } from 'react-twc';
 import { GAME_MODE } from '~/interfaces';
-import isE2E from '~/modules/utils/isE2E';
-import { cn } from '~/utils/cn';
+import { Button } from '~/modules/Elements/AKUI/Button';
+import { Menu } from '~/modules/Elements/AKUI/Menu';
+import Typography from '~/modules/Elements/AKUI/Primitives/Typography';
 import { PlayHistoryEntry } from './usePlayHistory';
 
 const GAME_MODE_LABELS: Record<string, string> = {
@@ -18,59 +19,82 @@ interface Props {
   focused?: boolean;
   onClick?: () => void;
   'data-test'?: string;
-  // Destructured separately to prevent double-spreading onto Card
+  // Destructured to prevent double-spreading; Button handles focus styling via the focused prop
   'data-focused'?: boolean;
 }
 
 export function PlayEntryCard({ entry, isExpanded, focused, onClick, 'data-focused': _dataFocused, ...rest }: Props) {
-  const songTitle = entry.song ? entry.song.title : 'Deleted song';
-  const songArtist = entry.song ? entry.song.artist : '';
+  const isDeleted = !entry.song;
+  const songTitle = entry.song?.title ?? '[Deleted song]';
+  const songArtist = entry.song?.artist ?? '';
   const time = dayjs(entry.date).format('h:mm A');
+  const thumbnailUrl = entry.song?.video ? `https://i3.ytimg.com/vi/${entry.song.video}/hqdefault.jpg` : null;
 
   return (
-    <Card
-      data-focused={focused}
-      // Mirrors the focus state logic used in ButtonBase (src/modules/Elements/AKUI/Button.tsx)
-      className={cn(!isE2E() && focused && 'bg-active scale-[1.025]')}
+    <Button
+      className="h-auto flex-col! items-stretch gap-0 p-0 text-left normal-case"
+      focused={focused}
+      subtleFocused={focused}
       onClick={onClick}
       {...rest}>
-      <CollapsedRow>
-        <SongInfo>
-          <Title>{songTitle}</Title>
-          {songArtist && <Artist>{songArtist}</Artist>}
-        </SongInfo>
-        <Time>{time}</Time>
-      </CollapsedRow>
-
-      {isExpanded && (
-        <Details data-test="history-entry-details">
-          <DetailRow>
-            <span>Mode</span>
-            <span>{GAME_MODE_LABELS[entry.mode] ?? entry.mode}</span>
-          </DetailRow>
-          {entry.progress !== undefined && (
-            <DetailRow>
-              <span>Completion</span>
-              <span>{Math.round(entry.progress * 100)}%</span>
-            </DetailRow>
-          )}
-          {entry.scores.map((score) => (
-            <DetailRow key={score.name}>
-              <span>{score.name}</span>
-              <span>{score.score.toLocaleString()}</span>
-            </DetailRow>
-          ))}
-        </Details>
-      )}
-    </Card>
+      {/* Top row: text content on the left, thumbnail on the right */}
+      <div className="flex items-start">
+        <div className="flex flex-1 flex-col gap-1 px-4 py-3">
+          <Typography className="text-active text-md">{songTitle}</Typography>
+          <div className="flex items-center justify-between gap-2">
+            {isDeleted && <Typography className="block text-sm opacity-50">{entry.songKey}</Typography>}
+            {songArtist && <Typography className="block text-sm text-slate-300">{songArtist}</Typography>}
+            <Typography className="shrink-0 text-sm opacity-70">{time}</Typography>
+          </div>
+        </div>
+        {thumbnailUrl ? (
+          // self-start: stays at aspect-video height, does not grow when the card expands
+          <img
+            src={thumbnailUrl}
+            alt=""
+            className="mt-1 mr-1 aspect-video w-32 shrink-0 self-start rounded-r-[4px] object-cover"
+          />
+        ) : (
+          // Placeholder when song has been deleted or has no video
+          <div className="mt-1 mr-1 aspect-video w-32 shrink-0 self-start rounded-r-[4px] bg-white/10" />
+        )}
+      </div>
+      {/* Expandable section — sibling to the top row so the divider spans the full button width */}
+      {/* Grid trick: animates height from 0→auto by transitioning grid-template-rows */}
+      <div
+        className={`grid transition-[grid-template-rows] duration-300 ease-in-out ${
+          isExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        }`}>
+        <div className="min-h-0 overflow-hidden">
+          <Menu.Divider className="my-2" />
+          <div className="grid grid-cols-2 divide-x divide-white/20 px-4 pb-2" data-test="history-entry-details">
+            <div className="flex flex-col gap-1 pr-3">
+              <DetailRow>
+                <span>Mode</span>
+                <span>{GAME_MODE_LABELS[entry.mode] ?? entry.mode}</span>
+              </DetailRow>
+              {entry.progress !== undefined && (
+                <DetailRow>
+                  <span>Completion</span>
+                  <span>{Math.round(entry.progress * 100)}%</span>
+                </DetailRow>
+              )}
+            </div>
+            {/* Right column: player scores */}
+            <div className="flex flex-col gap-1 pl-3">
+              {entry.scores.map((score) => (
+                <DetailRow key={score.name}>
+                  <span>{score.name}</span>
+                  <span>{score.score.toLocaleString()}</span>
+                </DetailRow>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Button>
   );
 }
 
-const Card = twc.div`cursor-pointer rounded-lg px-6 py-4 transition-transform`;
-const CollapsedRow = twc.div`flex items-center justify-between gap-4`;
-const SongInfo = twc.div`flex flex-col`;
-const Title = twc.span`typography font-bold`;
-const Artist = twc.span`typography text-sm opacity-70`;
-const Time = twc.span`typography shrink-0 text-sm opacity-70`;
-const Details = twc.div`mt-3 flex flex-col gap-1 border-t border-white/20 pt-3`;
-const DetailRow = twc.div`typography flex justify-between text-sm`;
+// Used multiple times (mode + completion + one per player score) → TWC
+const DetailRow = twc(Typography)`flex justify-between text-sm`;

--- a/src/routes/History/PlayEntryCard.tsx
+++ b/src/routes/History/PlayEntryCard.tsx
@@ -52,6 +52,8 @@ export function PlayEntryCard({ entry, isExpanded, focused, onClick, 'data-focus
           <img
             src={thumbnailUrl}
             alt=""
+            loading="lazy"
+            decoding="async"
             className="mt-1 mr-1 aspect-video w-32 shrink-0 self-start rounded-r-[4px] object-cover"
           />
         ) : (

--- a/src/routes/History/usePlayHistory.test.ts
+++ b/src/routes/History/usePlayHistory.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { groupEntriesByDay } from './usePlayHistory';
+
+describe('groupEntriesByDay', () => {
+  it('groups entries from the same calendar day under one header', () => {
+    const entries = [
+      { date: '2026-05-19T21:00:00.000Z', songKey: 'a', song: null, progress: 1, mode: 'DUEL', scores: [] },
+      { date: '2026-05-19T20:00:00.000Z', songKey: 'b', song: null, progress: 1, mode: 'DUEL', scores: [] },
+      { date: '2026-05-18T20:00:00.000Z', songKey: 'c', song: null, progress: 1, mode: 'DUEL', scores: [] },
+    ] as any;
+
+    const groups = groupEntriesByDay(entries);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].entries).toHaveLength(2);
+    expect(groups[1].entries).toHaveLength(1);
+  });
+
+  it('returns empty array for no entries', () => {
+    expect(groupEntriesByDay([])).toEqual([]);
+  });
+});

--- a/src/routes/History/usePlayHistory.ts
+++ b/src/routes/History/usePlayHistory.ts
@@ -1,0 +1,90 @@
+import dayjs from 'dayjs';
+import { useAsync } from 'react-use';
+import { SingSetup, SongPreview } from '~/interfaces';
+import SongsService from '~/modules/Songs/SongsService';
+import { getAllStats, getSongKey } from '~/modules/Songs/stats/common';
+
+export interface PlayHistoryEntry {
+  songKey: string;
+  // null when the song has been removed from the library
+  song: SongPreview | null;
+  date: string;
+  progress: number | undefined;
+  mode: SingSetup['mode'];
+  scores: Array<{ name: string; score: number }>;
+}
+
+export interface PlayHistoryGroup {
+  // Human-readable label: "Today", "Yesterday", or "18 May 2026"
+  label: string;
+  entries: PlayHistoryEntry[];
+}
+
+export function groupEntriesByDay(entries: PlayHistoryEntry[]): PlayHistoryGroup[] {
+  const groups: PlayHistoryGroup[] = [];
+  let currentDayKey = '';
+  let currentGroup: PlayHistoryGroup | null = null;
+
+  const today = dayjs();
+
+  for (const entry of entries) {
+    const entryDay = dayjs(entry.date);
+    const dayKey = entryDay.format('YYYY-MM-DD');
+
+    if (dayKey !== currentDayKey) {
+      currentDayKey = dayKey;
+
+      let label: string;
+      if (entryDay.isSame(today, 'day')) {
+        label = 'Today';
+      } else if (entryDay.isSame(today.subtract(1, 'day'), 'day')) {
+        label = 'Yesterday';
+      } else {
+        label = entryDay.format('D MMMM YYYY');
+      }
+
+      currentGroup = { label, entries: [] };
+      groups.push(currentGroup);
+    }
+
+    currentGroup!.entries.push(entry);
+  }
+
+  return groups;
+}
+
+export function usePlayHistory(): { groups: PlayHistoryGroup[]; loading: boolean } {
+  const statsAsync = useAsync(() => getAllStats(), []);
+  const songIndexAsync = useAsync(() => SongsService.getIndex(), []);
+
+  if (statsAsync.loading || songIndexAsync.loading || !statsAsync.value || !songIndexAsync.value) {
+    return { groups: [], loading: true };
+  }
+
+  // Build hash → SongPreview lookup map
+  const songsByKey = new Map<string, SongPreview>();
+  for (const song of songIndexAsync.value) {
+    songsByKey.set(getSongKey(song), song);
+  }
+
+  // Flatten all score entries across all songs
+  const flatEntries: PlayHistoryEntry[] = [];
+  for (const [key, stats] of Object.entries(statsAsync.value)) {
+    const song = songsByKey.get(key) ?? null;
+    for (const scoreEntry of stats.scores) {
+      flatEntries.push({
+        songKey: key,
+        song,
+        date: scoreEntry.date,
+        progress: scoreEntry.progress,
+        mode: scoreEntry.setup.mode,
+        scores: scoreEntry.scores,
+      });
+    }
+  }
+
+  // Sort newest first
+  flatEntries.sort((a, b) => b.date.localeCompare(a.date));
+
+  return { groups: groupEntriesByDay(flatEntries), loading: false };
+}

--- a/src/routes/History/usePlayHistory.ts
+++ b/src/routes/History/usePlayHistory.ts
@@ -57,8 +57,13 @@ export function usePlayHistory(): { groups: PlayHistoryGroup[]; loading: boolean
   const statsAsync = useAsync(() => getAllStats(), []);
   const songIndexAsync = useAsync(() => SongsService.getIndex(), []);
 
-  if (statsAsync.loading || songIndexAsync.loading || !statsAsync.value || !songIndexAsync.value) {
+  if (statsAsync.loading || songIndexAsync.loading) {
     return { groups: [], loading: true };
+  }
+
+  // Treat errors or missing values as empty (e.g. IndexedDB unavailable)
+  if (statsAsync.error || songIndexAsync.error || !statsAsync.value || !songIndexAsync.value) {
+    return { groups: [], loading: false };
   }
 
   // Build hash → SongPreview lookup map

--- a/src/routes/Welcome/Welcome.tsx
+++ b/src/routes/Welcome/Welcome.tsx
@@ -44,6 +44,9 @@ function Welcome() {
           <SmoothLink to="jukebox/">
             <Menu.Button {...register('jukebox', () => navigate('jukebox/'))}>Jukebox</Menu.Button>
           </SmoothLink>
+          <SmoothLink to="history/">
+            <Menu.Button {...register('history', () => navigate('history/'))}>History</Menu.Button>
+          </SmoothLink>
           <SmoothLink to="manage-songs/">
             <Menu.Button {...register('manage-songs', () => navigate('manage-songs/'))}>Manage Songs</Menu.Button>
           </SmoothLink>

--- a/src/routes/routePaths.ts
+++ b/src/routes/routePaths.ts
@@ -10,6 +10,7 @@ const routePaths = {
   GAME: 'game',
   MENU: 'menu',
   JUKEBOX: 'jukebox',
+  HISTORY: 'history',
   SELECT_INPUT: 'select-input',
   SETTINGS: 'settings',
   SETTINGS_REMOTE_MICS: 'settings/remote-mics',

--- a/tests/PageObjects/HistoryPage.ts
+++ b/tests/PageObjects/HistoryPage.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserContext, Page } from '@playwright/test';
+import { Browser, BrowserContext, expect, Page } from '@playwright/test';
 
 export class HistoryPagePO {
   constructor(
@@ -20,9 +20,7 @@ export class HistoryPagePO {
   }
 
   public async expectEntryCount(count: number) {
-    await this.entries.nth(count - 1).waitFor();
-    const actual = await this.entries.count();
-    if (actual !== count) throw new Error(`Expected ${count} entries, got ${actual}`);
+    await expect(this.entries).toHaveCount(count);
   }
 
   public async navigateToEntry(index: number) {

--- a/tests/PageObjects/HistoryPage.ts
+++ b/tests/PageObjects/HistoryPage.ts
@@ -1,0 +1,42 @@
+import { Browser, BrowserContext, Page } from '@playwright/test';
+
+export class HistoryPagePO {
+  constructor(
+    private page: Page,
+    private context: BrowserContext,
+    private browser: Browser,
+  ) {}
+
+  public get container() {
+    return this.page.getByTestId('history-page');
+  }
+
+  public get emptyState() {
+    return this.page.getByTestId('history-empty-state');
+  }
+
+  public get entries() {
+    return this.page.getByTestId('history-entry');
+  }
+
+  public async expectEntryCount(count: number) {
+    await this.entries.nth(count - 1).waitFor();
+    const actual = await this.entries.count();
+    if (actual !== count) throw new Error(`Expected ${count} entries, got ${actual}`);
+  }
+
+  public async navigateToEntry(index: number) {
+    // Move keyboard focus to this entry (0-based index from top)
+    for (let i = 0; i < index; i++) {
+      await this.page.keyboard.press('ArrowDown');
+    }
+  }
+
+  public async expandFocusedEntry() {
+    await this.page.keyboard.press('Enter');
+  }
+
+  public get expandedDetails() {
+    return this.page.getByTestId('history-entry-details');
+  }
+}

--- a/tests/PageObjects/MainMenuPage.ts
+++ b/tests/PageObjects/MainMenuPage.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserContext, Page } from '@playwright/test';
+import { Browser, BrowserContext, expect, Page } from '@playwright/test';
 import { Toolbar } from '../components/Toolbar';
 import navigateWithKeyboard from '../steps/navigateWithKeyboard';
 
@@ -44,7 +44,7 @@ export class MainMenuPagePO {
   }
 
   public async waitForContainer() {
-    await this.singSongButton.waitFor();
+    await expect(this.singSongButton).toBeVisible();
   }
 
   public get manageButton() {

--- a/tests/PageObjects/MainMenuPage.ts
+++ b/tests/PageObjects/MainMenuPage.ts
@@ -39,6 +39,14 @@ export class MainMenuPagePO {
     await this.page.getByTestId('jukebox').click();
   }
 
+  public async goToHistory() {
+    await this.page.getByTestId('history').click();
+  }
+
+  public async waitForContainer() {
+    await this.singSongButton.waitFor();
+  }
+
   public get manageButton() {
     return this.page.getByTestId('manage-songs');
   }

--- a/tests/PageObjects/initialise.ts
+++ b/tests/PageObjects/initialise.ts
@@ -4,6 +4,7 @@ import { AdvancedConnectionPagePO } from './AdvancedConnectionPage';
 import { ComputersMicConnectionPagePO } from './ComputersMicConnectionPage';
 import { EditSongsPagePO } from './EditSongsPage';
 import { GamePagePO } from './GamePage';
+import { HistoryPagePO } from './HistoryPage';
 import { InputSelectionPagePO } from './InputSelectionPage';
 import { JoinExistingGamePagePO } from './JoinExistingGamePage';
 import { JukeboxPagePO } from './JukeboxPage';
@@ -46,6 +47,7 @@ export default function initialise(page: Page, context: BrowserContext, browser:
     postGameResultsPage: new PostGameResultsPagePO(page, context, browser),
     postGameHighScoresPage: new PostGameHighScoresPagePO(page, context, browser),
     jukeboxPage: new JukeboxPagePO(page, context, browser),
+    historyPage: new HistoryPagePO(page, context, browser),
     remoteMicMainPage: new RemoteMicMainPagePO(page, context, browser),
     singstarConnectionPage: new SingstarConnectionPagePO(page, context, browser),
     computersMicConnectionPage: new ComputersMicConnectionPagePO(page, context, browser),

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -27,3 +27,55 @@ test('History page', async ({ page }) => {
     await pages.mainMenuPage.waitForContainer();
   });
 });
+
+test('History entry appears after a play is recorded', async ({ page }) => {
+  await page.goto('/?e2e-test');
+
+  await test.step('Load the app to ensure LocalForage is initialised', async () => {
+    await pages.landingPage.enterTheGame();
+  });
+
+  await test.step('Seed a play entry directly into LocalForage', async () => {
+    // Write a fake SongStats entry directly via IndexedDB to avoid playing a full song in the test.
+    // The key 'e2e-single-english-1995' matches the mock song fixture ID used by getSongKey().
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve, reject) => {
+        const request = indexedDB.open('localforage');
+        request.onsuccess = () => {
+          const db = request.result;
+          try {
+            const transaction = db.transaction('keyvaluepairs', 'readwrite');
+            transaction.objectStore('keyvaluepairs').put(
+              {
+                plays: 1,
+                scores: [
+                  {
+                    setup: { id: 'test-id', players: [{ track: 0, number: 0 }], mode: 'DUEL', tolerance: 2 },
+                    scores: [{ name: 'TestPlayer', score: 100000 }],
+                    date: new Date().toISOString(),
+                    progress: 1,
+                  },
+                ],
+              },
+              'e2e-single-english-1995',
+            );
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => reject(new Error('IndexedDB transaction failed'));
+          } catch (error) {
+            reject(error);
+          }
+        };
+        request.onerror = () => reject(new Error('Failed to open IndexedDB'));
+      });
+    });
+  });
+
+  await test.step('Navigate to History', async () => {
+    await pages.mainMenuPage.goToHistory();
+    await pages.historyPage.container.waitFor();
+  });
+
+  await test.step('The play entry appears in the history', async () => {
+    await pages.historyPage.expectEntryCount(1);
+  });
+});

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { initTestMode, mockSongs } from './helpers';
 import initialise from './PageObjects/initialise';
 
@@ -15,16 +15,16 @@ test('History page', async ({ page }) => {
   await test.step('Navigate from main menu to History', async () => {
     await pages.landingPage.enterTheGame();
     await pages.mainMenuPage.goToHistory();
-    await pages.historyPage.container.waitFor();
+    await expect(pages.historyPage.container).toBeVisible();
   });
 
   await test.step('Shows empty state when no songs have been sung', async () => {
-    await pages.historyPage.emptyState.waitFor();
+    await expect(pages.historyPage.emptyState).toBeVisible();
   });
 
   await test.step('Back to menu via backspace', async () => {
     await page.keyboard.press('Backspace');
-    await pages.mainMenuPage.waitForContainer();
+    await expect(pages.mainMenuPage.singSongButton).toBeVisible();
   });
 });
 
@@ -41,6 +41,13 @@ test('History entry appears after a play is recorded', async ({ page }) => {
     await page.evaluate(async () => {
       await new Promise<void>((resolve, reject) => {
         const request = indexedDB.open('localforage');
+        // Create the 'keyvaluepairs' store if the DB is being opened for the first time
+        // (i.e. before LocalForage has initialised it by visiting the History page).
+        // LocalForage checks objectStoreNames before creating, so this is safe even if it later
+        // upgrades the DB version.
+        request.onupgradeneeded = () => {
+          request.result.createObjectStore('keyvaluepairs');
+        };
         request.onsuccess = () => {
           const db = request.result;
           try {
@@ -72,7 +79,7 @@ test('History entry appears after a play is recorded', async ({ page }) => {
 
   await test.step('Navigate to History', async () => {
     await pages.mainMenuPage.goToHistory();
-    await pages.historyPage.container.waitFor();
+    await expect(pages.historyPage.container).toBeVisible();
   });
 
   await test.step('The play entry appears in the history', async () => {

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -1,0 +1,29 @@
+import { test } from '@playwright/test';
+import { initTestMode, mockSongs } from './helpers';
+import initialise from './PageObjects/initialise';
+
+let pages: ReturnType<typeof initialise>;
+test.beforeEach(async ({ page, context, browser }) => {
+  pages = initialise(page, context, browser);
+  await initTestMode({ page, context });
+  await mockSongs({ page, context });
+});
+
+test('History page', async ({ page }) => {
+  await page.goto('/?e2e-test');
+
+  await test.step('Navigate from main menu to History', async () => {
+    await pages.landingPage.enterTheGame();
+    await pages.mainMenuPage.goToHistory();
+    await pages.historyPage.container.waitFor();
+  });
+
+  await test.step('Shows empty state when no songs have been sung', async () => {
+    await pages.historyPage.emptyState.waitFor();
+  });
+
+  await test.step('Back to menu via backspace', async () => {
+    await page.keyboard.press('Backspace');
+    await pages.mainMenuPage.waitForContainer();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Singing History** page that shows all previously played songs, grouped by day.

### Features

- **History page** (`/history/`) accessible from the main menu
- Songs grouped by day with "Today" / "Yesterday" / date labels
- Each entry shows song title, artist, time, and thumbnail
- **Expandable cards** — press Enter or click to reveal mode, completion %, and per-player scores
- Expand/collapse animated via CSS grid-template-rows trick (no layout shift)
- Deleted songs still appear with their key shown as a fallback
- Keyboard navigation via existing `useKeyboardNav` hook

### Implementation

- `src/routes/History/HistoryPage.tsx` — main page component
- `src/routes/History/PlayEntryCard.tsx` — expandable card for one play entry
- `src/routes/History/usePlayHistory.ts` — data hook: reads from LocalForage stats + song index, groups by day
- `src/modules/Elements/AKUI/Menu.tsx` — `Menu.Divider` now accepts `className` prop
- `tests/history.spec.ts` — E2E tests (empty state + seeded entry via IndexedDB)
- `tests/PageObjects/HistoryPage.ts` — page object for history page
- `tests/PageObjects/MainMenuPage.ts` — added `goToHistory()` method
