### PR TITLE
feat: Add volume control to game and settings

### DIFF
--- a/src/modules/elements/video-player/direct-video.tsx
+++ b/src/modules/elements/video-player/direct-video.tsx
@@ -11,6 +11,7 @@ export default function DirectVideoPlayer({
   autoplay = true,
   startAt,
   controls,
+  volume,
   width,
   height,
   onStateChange,
@@ -62,7 +63,11 @@ export default function DirectVideoPlayer({
           player.current.playbackRate = speed;
         }
       },
-      setVolume: () => undefined,
+      setVolume: (newVolume: number) => {
+        if (player.current) {
+          player.current.volume = Math.min(1, Math.max(0, newVolume / 100));
+        }
+      },
       getCurrentTime: () => {
         return Promise.resolve(player.current?.currentTime ?? 0);
       },
@@ -92,6 +97,12 @@ export default function DirectVideoPlayer({
   useEffect(() => {
     startAt !== undefined && playerApi.seekTo(startAt);
   }, [startAt, playerApi]);
+
+  useEffect(() => {
+    if (player.current) {
+      player.current.volume = Math.min(1, Math.max(0, volume ?? 0.5));
+    }
+  }, [volume]);
 
   return (
     <video style={{ width: size.w, height: size.h }} autoPlay={autoplay} controls={controls} ref={player}>

--- a/src/routes/game/components/game-volume-control.tsx
+++ b/src/routes/game/components/game-volume-control.tsx
@@ -1,0 +1,67 @@
+import { VolumeOff, VolumeUp } from '@mui/icons-material';
+import Slider from '@mui/material/Slider';
+import Typography from '~/modules/elements/akui/primitives/typography';
+
+interface Props {
+  volume: number;
+  onChange: (volume: number) => void;
+  onChangeCommitted?: (volume: number) => void;
+}
+
+const clampVolume = (volume: number) => Math.min(1, Math.max(0, volume));
+
+const getSliderVolume = (value: number | number[]) => {
+  const rawValue = Array.isArray(value) ? value[0] : value;
+  return clampVolume(rawValue / 100);
+};
+
+export default function GameVolumeControl({ volume, onChange, onChangeCommitted }: Props) {
+  const safeVolume = clampVolume(volume);
+  const Icon = safeVolume === 0 ? VolumeOff : VolumeUp;
+  const percentage = Math.round(safeVolume * 100);
+
+  return (
+    <div
+      className="shadow-focusable pointer-events-auto fixed right-4 bottom-4 z-20002 mr-4 flex h-48 flex-col items-center gap-3 rounded-md bg-black/75 px-3 py-3 text-white backdrop-blur-md"
+      data-test="game-volume-control"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}>
+      <Icon className="text-active h-6! w-6!" />
+
+      <Slider
+        aria-label="Game volume"
+        data-test="game-volume-slider"
+        max={100}
+        min={0}
+        onChange={(_, value) => {
+          onChange(getSliderVolume(value));
+        }}
+        onChangeCommitted={(_, value) => {
+          onChangeCommitted?.(getSliderVolume(value));
+        }}
+        orientation="vertical"
+        step={1}
+        value={percentage}
+        sx={{
+          color: 'orange',
+          height: '7rem',
+          '& .MuiSlider-rail': {
+            backgroundColor: 'rgba(255, 255, 255, 0.35)',
+            opacity: 1,
+          },
+          '& .MuiSlider-thumb': {
+            backgroundColor: 'white',
+            border: '2px solid orange',
+            height: '1rem',
+            width: '1rem',
+          },
+          '& .MuiSlider-track': {
+            border: 0,
+          },
+        }}
+      />
+
+      <Typography className="w-10 text-center text-sm">{percentage}%</Typography>
+    </div>
+  );
+}

--- a/src/routes/game/game.tsx
+++ b/src/routes/game/game.tsx
@@ -8,11 +8,15 @@ import useFullscreen from '~/modules/hooks/use-fullscreen';
 import useQueryParam from '~/modules/hooks/use-query-param';
 import { woosh } from '~/modules/sound-manager';
 import startViewTransition from '~/modules/utils/start-view-transition';
+import GameVolumeControl from '~/routes/game/components/game-volume-control';
+import { GameVolumeSetting, useSettingValue } from '~/routes/settings/settings-state';
 import SingASong from '~/routes/sing-a-song/sing-a-song';
 import Singing from './singing/singing';
 
 function Game() {
   const songId = useQueryParam('song');
+  const [savedGameVolume, setSavedGameVolume] = useSettingValue(GameVolumeSetting);
+  const [gameVolume, setGameVolume] = useState(savedGameVolume);
 
   const [singSetup, setSingSetup] = useState<(SingSetup & { song: SongPreview }) | null>(null);
   const [preselectedSong, setPreselectedSong] = useState<string | null>(songId ?? null);
@@ -52,14 +56,16 @@ function Game() {
             key={resetKey}
             songPreview={singSetup.song}
             singSetup={singSetup}
+            gameVolume={gameVolume}
             returnToSongSelection={() => {
               setPreselectedSong(singSetup.song.id);
               setSingSetup(null);
             }}
           />
         ) : (
-          <SingASong onSongSelected={handleSelect} preselectedSong={preselectedSong} />
+          <SingASong gameVolume={gameVolume} onSongSelected={handleSelect} preselectedSong={preselectedSong} />
         )}
+        <GameVolumeControl volume={gameVolume} onChange={setGameVolume} onChangeCommitted={setSavedGameVolume} />
       </NoPrerender>
     </>
   );

--- a/src/routes/game/singing/player.tsx
+++ b/src/routes/game/singing/player.tsx
@@ -36,6 +36,7 @@ interface Props extends Omit<ComponentProps<'div'>, 'ref'>, RefAttributes<Player
   effectsEnabled?: boolean;
   pauseMenu?: boolean;
   restartSong?: () => void;
+  gameVolume?: number;
 }
 
 export interface PlayerRef {
@@ -73,6 +74,7 @@ function Player({
   effectsEnabled = true,
   singSetup,
   restartSong,
+  gameVolume = 1,
   pauseMenu = false,
   ref,
   ...restProps
@@ -123,6 +125,8 @@ function Player({
   );
 
   const isPauseMenuAvailable = pauseMenu;
+  const songVolume = newVolumeFFEnabled ? (song.volume ?? song.manualVolume) : song.manualVolume;
+  const effectiveVolume = (songVolume ?? 0.5) * gameVolume;
 
   const openPauseMenu = () => {
     setPauseMenuVisible(true);
@@ -206,7 +210,7 @@ function Player({
           controls={showControls}
           autoplay={autoplay}
           disablekb={process.env.NODE_ENV !== 'development'}
-          volume={newVolumeFFEnabled ? (song.volume ?? song.manualVolume) : song.manualVolume}
+          volume={effectiveVolume}
           startAt={song.videoGap ?? 0}
           onStateChange={onStateChangeCallback}
         />

--- a/src/routes/game/singing/singing.tsx
+++ b/src/routes/game/singing/singing.tsx
@@ -24,8 +24,9 @@ interface Props {
   songPreview: SongPreview;
   returnToSongSelection: () => void;
   restartSong: () => void;
+  gameVolume: number;
 }
-function Singing({ songPreview, singSetup, returnToSongSelection, restartSong }: Props) {
+function Singing({ songPreview, singSetup, returnToSongSelection, restartSong, gameVolume }: Props) {
   useFullscreen();
   useBlockScroll();
   const player = useRef<PlayerRef | null>(null);
@@ -120,6 +121,7 @@ function Singing({ songPreview, singSetup, returnToSongSelection, restartSong }:
               ref={player}
               onStatusChange={setPlayerState}
               song={song.data}
+              gameVolume={gameVolume}
               width={width}
               height={height}
               autoplay={false}

--- a/src/routes/settings/settings-state.ts
+++ b/src/routes/settings/settings-state.ts
@@ -61,6 +61,7 @@ export const ExcludedLanguagesSetting = new Setting<string[] | null>('EXCLUDED_L
 
 export const MobilePhoneModeSetting = new Setting<boolean | null>('MOBILE_PHONE_MODE_KEY', null);
 export const KeyboardHelpVisibilitySetting = new Setting<boolean>('keyboard-help-visibility', true);
+export const GameVolumeSetting = new Setting<number>('GameVolumeSetting', 1);
 
 const initialInputLag = posthog.getFeatureFlagPayload?.(FeatureFlags.InitialInputLag);
 export const InputLagSetting = new Setting<milliseconds>(

--- a/src/routes/sing-a-song/song-selection/components/song-preview.tsx
+++ b/src/routes/sing-a-song/song-selection/components/song-preview.tsx
@@ -22,6 +22,7 @@ interface Props {
   isPopular: boolean;
   forceFlag: boolean;
   onExpand: () => void;
+  gameVolume?: number;
 }
 
 const PREVIEW_LENGTH = 30;
@@ -38,6 +39,7 @@ export default function SongPreviewComponent({
   isPopular,
   forceFlag,
   onExpand,
+  gameVolume = 1,
 }: Props) {
   const [showVideo, setShowVideo] = useState(false);
   const player = useRef<VideoPlayerRef | null>(null);
@@ -73,9 +75,10 @@ export default function SongPreviewComponent({
   const songPreviewVolume = newVolumeFFEnabled
     ? (songPreview.volume ?? songPreview.manualVolume)
     : songPreview.manualVolume;
+  const effectiveVolume = (songPreviewVolume ?? 0.5) * gameVolume;
   const undebounced = useMemo(
-    () => [songPreview.video, start, end, songPreviewVolume] as const,
-    [songPreview.video, start, end, songPreviewVolume],
+    () => [songPreview.video, start, end, effectiveVolume] as const,
+    [songPreview.video, start, end, effectiveVolume],
   );
   const [videoId, previewStart, previewEnd, volume] = useDebounce(undebounced, 350);
 

--- a/src/routes/sing-a-song/song-selection/song-selection.tsx
+++ b/src/routes/sing-a-song/song-selection/song-selection.tsx
@@ -28,6 +28,7 @@ import { cn } from '~/utils/cn';
 interface Props {
   onSongSelected: (songSetup: SingSetup & { song: SongPreviewEntity }) => void;
   preselectedSong: string | null;
+  gameVolume: number;
 }
 
 declare global {
@@ -38,7 +39,7 @@ declare global {
     | undefined;
 }
 
-export default function SongSelection({ onSongSelected, preselectedSong }: Props) {
+export default function SongSelection({ onSongSelected, preselectedSong, gameVolume }: Props) {
   const setlist = useSetlist();
   const [additionalSong, setAdditionalSong] = useState<string | null>(preselectedSong);
   const list = useRef<VirtualizedListMethods | null>(null);
@@ -330,6 +331,7 @@ export default function SongSelection({ onSongSelected, preselectedSong }: Props
                   onExitKeyboardControl: () => setKeyboardControl(true),
                   onExpand: expandSong,
                   songPreview,
+                  gameVolume,
                   top: previewTop,
                   left: previewLeft,
                   width: Math.floor(songEntryWidth),

--- a/tests/game-volume.spec.ts
+++ b/tests/game-volume.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { initTestMode, mockSongs } from './helpers';
+import initialise from './page-objects/initialise';
+
+let pages: ReturnType<typeof initialise>;
+
+test.beforeEach(async ({ page, context, browser }) => {
+  pages = initialise(page, context, browser);
+  await initTestMode({ page, context });
+  await mockSongs({ page, context });
+});
+
+test('Game volume slider is visible and persists through singing', async ({ page }) => {
+  await page.goto('/?e2e-test');
+
+  await test.step('Select Advanced input setup', async () => {
+    await pages.landingPage.enterTheGame();
+    await pages.mainMenuPage.goToInputSelectionPage();
+    await pages.inputSelectionPage.selectAdvancedSetup();
+    await pages.advancedConnectionPage.goToMainMenu();
+    await pages.mainMenuPage.goToSingSong();
+  });
+
+  await test.step('Show the control on song selection', async () => {
+    await pages.songLanguagesPage.ensureSongLanguageIsSelected('English');
+    await pages.songLanguagesPage.continueAndGoToSongList();
+    await expect(pages.gamePage.gameVolumeControl).toBeVisible();
+    await pages.gamePage.setGameVolume(0.42);
+    await pages.gamePage.expectGameVolumeSliderValueToBe(0.42);
+    await pages.gamePage.expectDirectVideoVolumeToBe(0.21);
+  });
+
+  await test.step('Keep the control visible while singing', async () => {
+    await pages.songListPage.openPreviewForSong('e2e-single-english-1995');
+    await pages.songPreviewPage.playTheSong(false);
+    await expect(pages.gamePage.gameVolumeControl).toBeVisible();
+    await pages.gamePage.expectGameVolumeSliderValueToBe(0.42);
+    await pages.gamePage.expectDirectVideoVolumeToBe(0.21);
+  });
+});

--- a/tests/page-objects/game-page.ts
+++ b/tests/page-objects/game-page.ts
@@ -16,6 +16,43 @@ export class GamePagePO {
     return this.page.getByTestId('skip-intro-info');
   }
 
+  public get gameVolumeControl() {
+    return this.page.getByTestId('game-volume-control');
+  }
+
+  public get gameVolumeSlider() {
+    return this.gameVolumeControl.getByRole('slider', { name: 'Game volume' });
+  }
+
+  public get gameVolumeSliderRoot() {
+    return this.page.getByTestId('game-volume-slider');
+  }
+
+  public async setGameVolume(volume: number) {
+    const sliderBox = await this.gameVolumeSliderRoot.boundingBox();
+
+    if (!sliderBox) {
+      throw new Error('Game volume slider is not visible');
+    }
+
+    await this.page.mouse.click(sliderBox.x + sliderBox.width / 2, sliderBox.y + sliderBox.height * (1 - volume));
+  }
+
+  public async expectGameVolumeSliderValueToBe(volume: number) {
+    await expect(this.gameVolumeSlider).toHaveAttribute('aria-valuenow', `${Math.round(volume * 100)}`);
+  }
+
+  public async expectDirectVideoVolumeToBe(expectedVolume: number) {
+    await expect
+      .poll(async () =>
+        this.page
+          .locator('video')
+          .first()
+          .evaluate((video) => (video as HTMLVideoElement).volume),
+      )
+      .toBeCloseTo(expectedVolume, 2);
+  }
+
   public async skipIntroIfPossible() {
     try {
       const skipIntroEl = await this.page.waitForSelector('[data-test="skip-intro-info"]', { timeout: 5_000 });


### PR DESCRIPTION
a slider on the bottom right of the game route that allows the user to control the volume of the game, including both youtube and offline audio

The volume control is implemented using a context provider that manages the volume state and allows it to be accessed and updated from different components. The changes include modifications to the video player, game route, singing player, singing route, settings state, song preview, and song selection components. Additionally, a test have been added to ensure the functionality of the volume control