### PR TITLE
[codex] Remove shared song updated fallbacks

### DIFF
--- a/functions/admin/shared-songs.test.ts
+++ b/functions/admin/shared-songs.test.ts
@@ -34,7 +34,10 @@ describe('browser shared songs admin function', () => {
 
   it('returns list data', async () => {
     const kv = workerEnv.SHARED_SONGS_KV;
-    await upsertSharedSong(kv, generateSharedSongRecord({ externalSongId: 'external-1', firstSeenAt: 123 }));
+    await upsertSharedSong(
+      kv,
+      generateSharedSongRecord({ externalSongId: 'external-1', firstSeenAt: 123, updated: 123 }),
+    );
 
     const response = await fetchWorker('https://example.com/admin/shared-songs', createRequest());
 
@@ -74,7 +77,7 @@ describe('browser shared songs admin function', () => {
     const kv = workerEnv.SHARED_SONGS_KV;
     await kv.put(
       'shared-song:external-1',
-      JSON.stringify(generateSharedSongRecord({ externalSongId: 'external-1', firstSeenAt: 123 })),
+      JSON.stringify(generateSharedSongRecord({ externalSongId: 'external-1', firstSeenAt: 123, updated: 123 })),
     );
 
     const response = await fetchWorker('https://example.com/admin/shared-songs', createRequest({ method: 'PUT' }));

--- a/functions/shared-songs-admin.ts
+++ b/functions/shared-songs-admin.ts
@@ -5,13 +5,11 @@ interface Env {
   SHARED_SONGS_KV?: KVNamespace;
 }
 
-type IncomingSharedSongRecord = SharedSongRecord | Omit<SharedSongRecord, 'updated'>;
-
 const responseHeaders = {
   'Content-Type': 'application/json',
 };
 
-const isSharedSongRecord = (payload: unknown): payload is IncomingSharedSongRecord => {
+const isSharedSongRecord = (payload: unknown): payload is SharedSongRecord => {
   if (!payload || typeof payload !== 'object') {
     return false;
   }
@@ -27,7 +25,7 @@ const isSharedSongRecord = (payload: unknown): payload is IncomingSharedSongReco
     typeof record.videoId === 'string' &&
     typeof record.verifiedAt === 'number' &&
     typeof record.firstSeenAt === 'number' &&
-    (typeof record.updated === 'number' || typeof record.updated === 'undefined') &&
+    typeof record.updated === 'number' &&
     typeof record.lastSeenAt === 'number' &&
     typeof record.sourceUserId === 'string' &&
     typeof record.sourceEventAt === 'number'
@@ -63,10 +61,7 @@ export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
         });
       }
 
-      await upsertSharedSong(env.SHARED_SONGS_KV, {
-        ...payload,
-        updated: payload.updated ?? payload.firstSeenAt,
-      });
+      await upsertSharedSong(env.SHARED_SONGS_KV, payload);
 
       return new Response(JSON.stringify({ ok: true }), {
         headers: responseHeaders,

--- a/functions/shared-songs-store.test.ts
+++ b/functions/shared-songs-store.test.ts
@@ -68,50 +68,12 @@ describe('sharedSongsStore KV behavior', () => {
     ]);
   });
 
-  it('backfills updated from firstSeenAt for legacy records and index entries', async () => {
+  it('regenerates the index from stored records', async () => {
     const kv = workerEnv.SHARED_SONGS_KV;
-    const { updated: _, ...legacyRecord } = generateSharedSongRecord({
-      externalSongId: 'external-1',
-      firstSeenAt: 123,
-    });
-
-    await kv.put('shared-song:external-1', JSON.stringify(legacyRecord));
     await kv.put(
-      'shared-songs-index',
-      JSON.stringify([
-        {
-          externalSongId: 'external-1',
-          songId: 'song-1',
-          artist: 'Artist',
-          title: 'Title',
-          language: ['English'],
-          videoId: 'koBUXESJZ8g',
-          firstSeenAt: 123,
-        },
-      ]),
+      'shared-song:external-1',
+      JSON.stringify(generateSharedSongRecord({ externalSongId: 'external-1', firstSeenAt: 123, updated: 456 })),
     );
-
-    await expect(getSharedSong(kv, 'external-1')).resolves.toMatchObject({
-      externalSongId: 'external-1',
-      firstSeenAt: 123,
-      updated: 123,
-    });
-    await expect(listSharedSongs(kv)).resolves.toEqual([
-      expect.objectContaining({
-        externalSongId: 'external-1',
-        firstSeenAt: 123,
-        updated: 123,
-      }),
-    ]);
-  });
-
-  it('regenerates the index with first seen timestamps', async () => {
-    const kv = workerEnv.SHARED_SONGS_KV;
-    const { updated: _, ...legacyRecord } = generateSharedSongRecord({
-      externalSongId: 'external-1',
-      firstSeenAt: 123,
-    });
-    await kv.put('shared-song:external-1', JSON.stringify(legacyRecord));
 
     await regenerateIndex(kv);
 
@@ -119,7 +81,7 @@ describe('sharedSongsStore KV behavior', () => {
       expect.objectContaining({
         externalSongId: 'external-1',
         firstSeenAt: 123,
-        updated: 123,
+        updated: 456,
       }),
     ]);
   });

--- a/functions/shared-songs-store.ts
+++ b/functions/shared-songs-store.ts
@@ -19,36 +19,13 @@ export type SharedSongIndexEntry = Pick<
   'externalSongId' | 'songId' | 'artist' | 'title' | 'language' | 'videoId' | 'firstSeenAt' | 'updated'
 >;
 
-type StoredSharedSongRecord = SharedSongRecord | Omit<SharedSongRecord, 'updated'>;
-
-type StoredSharedSongIndexEntry =
-  | SharedSongIndexEntry
-  | Pick<SharedSongRecord, 'songId' | 'artist' | 'title' | 'language' | 'videoId'>
-  | Omit<SharedSongIndexEntry, 'updated'>;
-
 const SHARED_SONG_KEY_PREFIX = 'shared-song:';
 const INDEX_KEY = 'shared-songs-index';
 
 const getStorageKey = (externalSongId: string) => `${SHARED_SONG_KEY_PREFIX}${externalSongId}`;
 
-const normalizeRecord = (record: StoredSharedSongRecord | SharedSongRecord): SharedSongRecord => ({
-  ...record,
-  updated: 'updated' in record ? record.updated : record.firstSeenAt,
-});
-
-const normalizeIndexEntry = (entry: StoredSharedSongIndexEntry): SharedSongIndexEntry => ({
-  externalSongId: 'externalSongId' in entry ? entry.externalSongId : entry.songId,
-  songId: entry.songId,
-  artist: entry.artist,
-  title: entry.title,
-  language: entry.language,
-  videoId: entry.videoId,
-  firstSeenAt: 'firstSeenAt' in entry ? entry.firstSeenAt : 0,
-  updated: ('updated' in entry ? entry.updated : undefined) ?? ('firstSeenAt' in entry ? entry.firstSeenAt : 0),
-});
-
 const getIndex = async (kvNamespace: KVNamespace): Promise<SharedSongIndexEntry[]> =>
-  ((await kvNamespace.get<StoredSharedSongIndexEntry[]>(INDEX_KEY, 'json')) ?? []).map(normalizeIndexEntry);
+  (await kvNamespace.get<SharedSongIndexEntry[]>(INDEX_KEY, 'json')) ?? [];
 
 const addToIndex = async (kvNamespace: KVNamespace, entry: SharedSongIndexEntry) => {
   const index = await getIndex(kvNamespace);
@@ -68,23 +45,21 @@ export const listSharedSongs = async (kvNamespace: KVNamespace) => {
 };
 
 export const getSharedSong = async (kvNamespace: KVNamespace, externalSongId: string) => {
-  const record = await kvNamespace.get<StoredSharedSongRecord>(getStorageKey(externalSongId), 'json');
-  return record ? normalizeRecord(record) : null;
+  return kvNamespace.get<SharedSongRecord>(getStorageKey(externalSongId), 'json');
 };
 
-export const upsertSharedSong = async (kvNamespace: KVNamespace, record: StoredSharedSongRecord) => {
-  const normalizedRecord = normalizeRecord(record);
-  const storageKey = getStorageKey(normalizedRecord.externalSongId);
-  await kvNamespace.put(storageKey, JSON.stringify(normalizedRecord));
+export const upsertSharedSong = async (kvNamespace: KVNamespace, record: SharedSongRecord) => {
+  const storageKey = getStorageKey(record.externalSongId);
+  await kvNamespace.put(storageKey, JSON.stringify(record));
   await addToIndex(kvNamespace, {
-    externalSongId: normalizedRecord.externalSongId,
-    songId: normalizedRecord.songId,
-    artist: normalizedRecord.artist,
-    title: normalizedRecord.title,
-    language: normalizedRecord.language,
-    videoId: normalizedRecord.videoId,
-    firstSeenAt: normalizedRecord.firstSeenAt,
-    updated: normalizedRecord.updated,
+    externalSongId: record.externalSongId,
+    songId: record.songId,
+    artist: record.artist,
+    title: record.title,
+    language: record.language,
+    videoId: record.videoId,
+    firstSeenAt: record.firstSeenAt,
+    updated: record.updated,
   });
 };
 
@@ -142,8 +117,7 @@ export const regenerateIndex = async (kvNamespace: KVNamespace) => {
   const listResponse = await kvNamespace.list({ prefix: SHARED_SONG_KEY_PREFIX });
   const records = await Promise.all(
     listResponse.keys.map(async ({ name }) => {
-      const record = await kvNamespace.get<StoredSharedSongRecord>(name, 'json');
-      return record ? normalizeRecord(record) : null;
+      return kvNamespace.get<SharedSongRecord>(name, 'json');
     }),
   );
 

--- a/functions/test-utils.ts
+++ b/functions/test-utils.ts
@@ -10,7 +10,7 @@ export const generateSharedSongRecord = (overrides: Partial<SharedSongRecord> = 
   videoId: 'koBUXESJZ8g',
   verifiedAt: 1,
   firstSeenAt: overrides.firstSeenAt ?? 1,
-  updated: overrides.updated ?? overrides.firstSeenAt ?? 1,
+  updated: overrides.updated ?? 1,
   lastSeenAt: 1,
   sourceUserId: 'user-1',
   sourceEventAt: 1,

--- a/tests/shared-songs-admin-helper.ts
+++ b/tests/shared-songs-admin-helper.ts
@@ -50,7 +50,6 @@ export const upsertSharedSong = async (
 ) => {
   const now = Date.now();
   const firstSeenAt = overrides.firstSeenAt ?? now;
-  const updated = overrides.updated ?? firstSeenAt;
   const payload = {
     externalSongId,
     songId: sharedCloudflareSongFixture.songId,
@@ -61,7 +60,7 @@ export const upsertSharedSong = async (
     videoId: sharedCloudflareSongFixture.videoId,
     verifiedAt: now,
     firstSeenAt,
-    updated,
+    updated: overrides.updated ?? now,
     lastSeenAt: now,
     sourceUserId,
     sourceEventAt: now,


### PR DESCRIPTION
## What changed
Removed all fallback handling for missing `updated` values in shared-song KV records and index entries. The storage layer, admin ingest path, and supporting fixtures/tests now treat `updated` as a required numeric field.

## Why
The `updated` field has been backfilled for all existing unverified songs and new songs now always include it. Keeping compatibility branches for `undefined` values was dead code and kept the storage contract looser than the actual data.

## Impact
Shared-song KV reads and writes now assume the strict record shape everywhere. Admin payload validation rejects records that omit `updated`, and tests/fixtures no longer model legacy records without it.

## Root cause
The code still carried transitional support from when older KV records could be missing `updated`.

## Validation
- Pre-commit hooks during `git commit`
- `prettier --write`
- `eslint --cache --fix`
- `pnpm type-check`
- `pnpm run test --watch=false --changed --passWithNoTests`
- `pnpm knip`
- `pnpm vitest functions/shared-songs-store.test.ts functions/admin/shared-songs.test.ts functions/admin/shared-song.test.ts`