### PR TITLE
Filter benign workerd TLS log spam from CI E2E runs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -122,6 +122,7 @@ const config: PlaywrightTestConfig = {
           port: 3010,
           timeout: 60_000 * 3,
           reuseExistingServer: true,
+          ignoreHTTPSErrors: true,
         }
       : undefined,
     // {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -117,12 +117,13 @@ const config: PlaywrightTestConfig = {
       ? {
           // On CI we check the same build as would be deployed - with the risk that some issues won't happen locally
           command: process.env.CI
-            ? 'wrangler dev --port 3010 --local --local-protocol=https'
+            ? // workerd logs a benign "error accepting tls connection ... CERTIFICATE_UNKNOWN" for some of Chromium's
+              // parallel connections to its self-signed cert; tests pass regardless, so just filter the noise out.
+              `wrangler dev --port 3010 --local --local-protocol=https 2>&1 | awk '/error accepting tls connection.*CERTIFICATE_UNKNOWN/{skip=1;next} skip&&(/^[[:space:]]*$/||/stack:/){next} {skip=0;print}'`
             : 'VITE_APP_PRERENDER=true vite build && vite preview --port 3010',
           port: 3010,
           timeout: 60_000 * 3,
           reuseExistingServer: true,
-          ignoreHTTPSErrors: true,
         }
       : undefined,
     // {


### PR DESCRIPTION
## Summary
- The `webServer.ignoreHTTPSErrors` addition from the first version of this PR turned out to be a no-op: since the config uses `port` (not `url`), Playwright only does a raw TCP connect for its readiness check, never an actual HTTPS fetch.
- The real noise comes from workerd's own TLS accept implementation logging a `CERTIFICATE_UNKNOWN` alert for some of Chromium's parallel connections to its self-signed cert. This only happens in CI (the only place `wrangler dev`/workerd runs for E2E — locally `prodRun` uses `vite preview`, a plain Node https server), and tests already pass regardless (verified against [this run](https://github.com/Asvarox/allkaraoke/actions/runs/28706223280/job/85132208706?pr=568): 24 passed, 1 skipped, 203 of these log lines).
- Instead of chasing the workerd-internal cause, pipe `wrangler dev`'s output through a small `awk` filter in the CI-only command branch that drops just that error block (and its multi-line stack trace), leaving all other output — including genuinely different errors — untouched.

## Verification
- Downloaded the actual CI job log and ran the filter against it locally: all 203 `CERTIFICATE_UNKNOWN` lines removed, while an unrelated `Connection reset by peer` error (which also happened to have a `stack:` trailer) was correctly preserved.
- Ran `wrangler dev --port 3010 --local --local-protocol=https` through the filter locally and confirmed the server still starts and serves `https://localhost:3010/?e2e-test` (200 response).
- `pnpm type-check` passes.

## Test plan
- [x] CI E2E run should show no `CERTIFICATE_UNKNOWN` log spam, with the same pass/fail outcome as before.