### PR TITLE
Randomize unverified song queue processing order

### DIFF
--- a/src/routes/admin/unverified-song-management.tsx
+++ b/src/routes/admin/unverified-song-management.tsx
@@ -17,7 +17,7 @@ import useSmoothNavigate from '~/modules/hooks/use-smooth-navigate';
 import { RegenerateIndexButton } from './regenerate-index-button';
 import {
   buildAdminUnverifiedSongProcessingUrl,
-  getOldestAdminUnverifiedSong,
+  getRandomAdminUnverifiedSong,
 } from './unverified-song-processing-queue';
 import {
   AdminUnverifiedSong,
@@ -121,7 +121,7 @@ export function UnverifiedSongManagement({ password }: Props) {
     },
   });
 
-  const oldestSongToProcess = getOldestAdminUnverifiedSong(songs);
+  const hasSongsToProcess = songs.length > 0;
   const isBusy = isLoading || isValidating || isDeleting || isRegenerating;
   const error = listError ?? deleteError ?? regenerateError;
   const errorMessage = error instanceof Error ? error.message : null;
@@ -203,12 +203,14 @@ export function UnverifiedSongManagement({ password }: Props) {
           <Button
             variant="contained"
             onClick={() => {
-              if (oldestSongToProcess) {
-                navigate(buildAdminUnverifiedSongProcessingUrl(oldestSongToProcess.sharedSongId, true));
+              const songToProcess = getRandomAdminUnverifiedSong(songs);
+
+              if (songToProcess) {
+                navigate(buildAdminUnverifiedSongProcessingUrl(songToProcess.sharedSongId, true));
               }
             }}
-            disabled={isBusy || !oldestSongToProcess}>
-            Process oldest unverified
+            disabled={isBusy || !hasSongsToProcess}>
+            Process random unverified
           </Button>
           <RegenerateIndexButton disabled={isBusy} onRegenerate={() => void handleRegenerateIndex()} />
           <Button

--- a/src/routes/admin/unverified-song-processing-queue.ts
+++ b/src/routes/admin/unverified-song-processing-queue.ts
@@ -2,11 +2,14 @@ import { AdminUnverifiedSong } from './unverified-songs-admin-api';
 
 const adminEditSongPath = 'edit/song/';
 
-export const getOldestAdminUnverifiedSong = (
+export const getRandomAdminUnverifiedSong = (
   songs: AdminUnverifiedSong[],
   currentSharedSongId?: string,
-): AdminUnverifiedSong | undefined =>
-  [...songs].filter((song) => song.sharedSongId !== currentSharedSongId).sort((a, b) => a.updated - b.updated)[0];
+): AdminUnverifiedSong | undefined => {
+  const candidates = songs.filter((song) => song.sharedSongId !== currentSharedSongId);
+
+  return candidates[Math.floor(Math.random() * candidates.length)];
+};
 
 export const buildAdminUnverifiedSongProcessingUrl = (sharedSongId: string, processQueue = false) => {
   const searchParams = new URLSearchParams({
@@ -23,7 +26,7 @@ export const buildAdminUnverifiedSongProcessingUrl = (sharedSongId: string, proc
 };
 
 export const getNextAdminUnverifiedSongProcessingUrl = (songs: AdminUnverifiedSong[], currentSharedSongId: string) => {
-  const nextSong = getOldestAdminUnverifiedSong(songs, currentSharedSongId);
+  const nextSong = getRandomAdminUnverifiedSong(songs, currentSharedSongId);
 
   return nextSong ? buildAdminUnverifiedSongProcessingUrl(nextSong.sharedSongId, true) : 'admin/';
 };

--- a/tests/admin-unverified-songs.spec.ts
+++ b/tests/admin-unverified-songs.spec.ts
@@ -23,9 +23,11 @@ let currentVisibleTitle = '';
 let sharedSongIdsToRemove: string[] = [];
 
 const queueTestTitles = [
-  'saving during oldest-first processing redirects to the next unverified song',
-  'deleting during oldest-first processing redirects to the next unverified song',
+  'saving during queue processing redirects to the next unverified song',
+  'deleting during queue processing redirects to the next unverified song',
 ];
+
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim();
 
 const createSharedSongIdFromProjectAndTitle = (projectName: string, title: string) =>
   `admin-${projectName}-${title}`
@@ -104,6 +106,23 @@ const seedQueueSongs = async (request: APIRequestContext) => {
     updated: queueOldestUpdatedValue,
     sourceUserId: 'admin-panel-e2e',
   });
+
+  // Random queue selection picks from the whole queue, so any other unverified songs left over in the
+  // local KV store would make the "which song comes first" assertions non-deterministic. Scope the
+  // queue down to just the two songs these tests care about.
+  const response = await request.get('/admin/unverified-songs', {
+    headers: { 'x-admin-panel-password': adminPanelPassword },
+  });
+  const existingSongs = (await response.json()) as Array<{ sharedSongId: string }>;
+  const extraSharedSongIds = existingSongs
+    .map((song) => song.sharedSongId)
+    .filter((sharedSongId) => sharedSongId !== currentSharedSongId && sharedSongId !== oldestUpdatedSharedSongId);
+
+  // Deletes must run sequentially: removeUnverifiedSong does a read-modify-write of the shared
+  // index, so concurrent deletes race and can leave stale (already-deleted) entries in the index.
+  for (const sharedSongId of extraSharedSongIds) {
+    await removeUnverifiedSong(request, sharedSongId);
+  }
 
   return { oldestUpdatedSharedSongId, oldestUpdatedVisibleTitle };
 };
@@ -224,17 +243,9 @@ test('persists unverified songs table page size and sorting after reload', async
   await expect(pages.adminUnverifiedSongsPage.table.rowWithTitle(olderVisibleTitle)).toBeVisible();
 });
 
-test('saving during oldest-first processing redirects to the next unverified song', async ({
-  page,
-  request,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== 'chromium', 'Oldest-first queue tests share one KV namespace.');
+test('saving during queue processing redirects to the next unverified song', async ({ page, request }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Queue processing tests share one KV namespace.');
   const { oldestUpdatedSharedSongId, oldestUpdatedVisibleTitle } = await seedQueueSongs(request);
-  const syncedTitle = `${oldestUpdatedVisibleTitle} Synced`;
-  const syncedBpm = '190';
-  const syncedLyricsGap = '1234';
-  const syncedDesiredEnd = '9999';
-  const syncedTrackName = 'Queue Track Name';
   const currentQueueSongTxt = makeUnverifiedSongTxt({ title: currentVisibleTitle });
   const oldestQueueSongTxt = makeUnverifiedSongTxt({
     title: oldestUpdatedVisibleTitle,
@@ -244,26 +255,53 @@ test('saving during oldest-first processing redirects to the next unverified son
   });
   const currentQueueSong = getProcessedSong(currentQueueSongTxt);
   const oldestQueueSong = getProcessedSong(oldestQueueSongTxt);
-  const queueSongDefaultBpm = String(currentQueueSong.bpm);
-  const queueSongDefaultDesiredEnd = getDesiredEndTimeValue(currentQueueSong);
-  const oldestQueueSongDefaultBpm = String(oldestQueueSong.bpm);
-  const oldestQueueSongDefaultDesiredEnd = getDesiredEndTimeValue(oldestQueueSong);
+  const sharedSongIdsInQueue = [currentSharedSongId, oldestUpdatedSharedSongId];
+  const songSpecsBySharedSongId: Record<
+    string,
+    { visibleTitle: string; defaultBpm: string; defaultDesiredEnd: string }
+  > = {
+    [currentSharedSongId]: {
+      visibleTitle: currentVisibleTitle,
+      defaultBpm: String(currentQueueSong.bpm),
+      defaultDesiredEnd: getDesiredEndTimeValue(currentQueueSong),
+    },
+    [oldestUpdatedSharedSongId]: {
+      visibleTitle: oldestUpdatedVisibleTitle,
+      defaultBpm: String(oldestQueueSong.bpm),
+      defaultDesiredEnd: getDesiredEndTimeValue(oldestQueueSong),
+    },
+  };
 
   await page.goto('/admin?e2e-test');
 
   await pages.adminUnverifiedSongsPage.signIn(adminPanelPassword);
-  await pages.adminUnverifiedSongsPage.processOldestUnverifiedSong();
-  await pages.songEditBasicInfoPage.expectEditedSongHeaderToBe(
-    unverifiedCloudflareSongFixture.artist,
-    oldestUpdatedVisibleTitle,
+  await pages.adminUnverifiedSongsPage.processRandomUnverifiedSong();
+  await expect(pages.songEditBasicInfoPage.editedSongHeader).toBeVisible();
+
+  const firstHeaderText = normalizeWhitespace((await pages.songEditBasicInfoPage.editedSongHeader.textContent()) ?? '');
+  const firstSharedSongId = sharedSongIdsInQueue.find(
+    (sharedSongId) =>
+      firstHeaderText ===
+      normalizeWhitespace(
+        `${unverifiedCloudflareSongFixture.artist} - ${songSpecsBySharedSongId[sharedSongId].visibleTitle}`,
+      ),
   );
+  expect(firstSharedSongId, 'processing the queue should open one of the seeded unverified songs').toBeDefined();
+
+  const secondSharedSongId = sharedSongIdsInQueue.find((sharedSongId) => sharedSongId !== firstSharedSongId)!;
+  const firstSpec = songSpecsBySharedSongId[firstSharedSongId!];
+  const secondSpec = songSpecsBySharedSongId[secondSharedSongId];
+  const syncedTitle = `${firstSpec.visibleTitle} Synced`;
+  const syncedBpm = '190';
+  const syncedLyricsGap = '1234';
+  const syncedDesiredEnd = '9999';
+  const syncedTrackName = 'Queue Track Name';
+
   await expect(pages.songEditSyncLyricsToVideoPage.pageContainer).toBeVisible();
-  const oldestUpdatedSongVideoSource = await pages.songEditSyncLyricsToVideoPage.getVideoPlayerSource();
-  expect(oldestUpdatedSongVideoSource).not.toBeNull();
-  await expect(pages.songEditSyncLyricsToVideoPage.changeLyricsBpmInput).toHaveValue(oldestQueueSongDefaultBpm);
-  await expect(pages.songEditSyncLyricsToVideoPage.desiredSongEndTimeInput).toHaveValue(
-    oldestQueueSongDefaultDesiredEnd,
-  );
+  const firstSongVideoSource = await pages.songEditSyncLyricsToVideoPage.getVideoPlayerSource();
+  expect(firstSongVideoSource).not.toBeNull();
+  await expect(pages.songEditSyncLyricsToVideoPage.changeLyricsBpmInput).toHaveValue(firstSpec.defaultBpm);
+  await expect(pages.songEditSyncLyricsToVideoPage.desiredSongEndTimeInput).toHaveValue(firstSpec.defaultDesiredEnd);
   await pages.songEditSyncLyricsToVideoPage.enterLyricsBPM(syncedBpm);
   await pages.songEditSyncLyricsToVideoPage.enterLyricsGapShift(syncedLyricsGap);
   await pages.songEditSyncLyricsToVideoPage.enterDesiredSongEndTime(syncedDesiredEnd);
@@ -274,16 +312,13 @@ test('saving during oldest-first processing redirects to the next unverified son
 
   await pages.songEditBasicInfoPage.expectEditedSongHeaderToBe(
     unverifiedCloudflareSongFixture.artist,
-    currentVisibleTitle,
+    secondSpec.visibleTitle,
   );
   await expect(pages.songEditSyncLyricsToVideoPage.pageContainer).toBeVisible();
-  await expect(pages.songEditSyncLyricsToVideoPage.videoPlayerSource).not.toHaveAttribute(
-    'src',
-    oldestUpdatedSongVideoSource!,
-  );
-  await expect(pages.songEditSyncLyricsToVideoPage.changeLyricsBpmInput).toHaveValue(queueSongDefaultBpm);
+  await expect(pages.songEditSyncLyricsToVideoPage.videoPlayerSource).not.toHaveAttribute('src', firstSongVideoSource!);
+  await expect(pages.songEditSyncLyricsToVideoPage.changeLyricsBpmInput).toHaveValue(secondSpec.defaultBpm);
   await expect(pages.songEditSyncLyricsToVideoPage.lyricsGapShiftInput).toHaveValue('0');
-  await expect(pages.songEditSyncLyricsToVideoPage.desiredSongEndTimeInput).toHaveValue(queueSongDefaultDesiredEnd);
+  await expect(pages.songEditSyncLyricsToVideoPage.desiredSongEndTimeInput).toHaveValue(secondSpec.defaultDesiredEnd);
   await expect(pages.songEditSyncLyricsToVideoPage.trackNameInput).toHaveValue('');
 
   await expect
@@ -293,50 +328,61 @@ test('saving during oldest-first processing redirects to the next unverified son
       });
       const songs = (await response.json()) as Array<{ sharedSongId: string; title: string }>;
 
-      return songs.find((song) => song.sharedSongId === oldestUpdatedSharedSongId)?.title;
+      return songs.find((song) => song.sharedSongId === firstSharedSongId)?.title;
     })
     .toBe(syncedTitle);
 
-  const savedSongResponse = await request.get(`/unverified-song?id=${encodeURIComponent(oldestUpdatedSharedSongId)}`);
+  const savedSongResponse = await request.get(`/unverified-song?id=${encodeURIComponent(firstSharedSongId!)}`);
   await expect(savedSongResponse).toBeOK();
 
   const savedSong = (await savedSongResponse.json()) as { title: string; songTxt: string };
   expect(savedSong.title).toBe(syncedTitle);
   expect(savedSong.songTxt).toContain(`#BPM:${syncedBpm}`);
 
-  const nextSongResponse = await request.get(`/unverified-song?id=${encodeURIComponent(currentSharedSongId)}`);
+  const nextSongResponse = await request.get(`/unverified-song?id=${encodeURIComponent(secondSharedSongId)}`);
   await expect(nextSongResponse).toBeOK();
 
   const nextSong = (await nextSongResponse.json()) as { songTxt: string };
-  expect(nextSong.songTxt).toContain(`#BPM:${queueSongDefaultBpm}`);
+  expect(nextSong.songTxt).toContain(`#BPM:${secondSpec.defaultBpm}`);
 
   await page.goto('/admin?e2e-test');
   await pages.adminUnverifiedSongsPage.search(syncedTitle);
   await expect(pages.adminUnverifiedSongsPage.table.rowWithTitle(syncedTitle)).toBeVisible();
 });
 
-test('deleting during oldest-first processing redirects to the next unverified song', async ({
-  page,
-  request,
-}, testInfo) => {
-  test.skip(testInfo.project.name !== 'chromium', 'Oldest-first queue tests share one KV namespace.');
+test('deleting during queue processing redirects to the next unverified song', async ({ page, request }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Queue processing tests share one KV namespace.');
   const { oldestUpdatedSharedSongId, oldestUpdatedVisibleTitle } = await seedQueueSongs(request);
   page.once('dialog', (dialog) => dialog.accept());
+
+  const sharedSongIdsInQueue = [currentSharedSongId, oldestUpdatedSharedSongId];
+  const visibleTitleBySharedSongId: Record<string, string> = {
+    [currentSharedSongId]: currentVisibleTitle,
+    [oldestUpdatedSharedSongId]: oldestUpdatedVisibleTitle,
+  };
 
   await page.goto('/admin?e2e-test');
 
   await pages.adminUnverifiedSongsPage.signIn(adminPanelPassword);
-  await pages.adminUnverifiedSongsPage.processOldestUnverifiedSong();
-  await pages.songEditBasicInfoPage.expectEditedSongHeaderToBe(
-    unverifiedCloudflareSongFixture.artist,
-    oldestUpdatedVisibleTitle,
+  await pages.adminUnverifiedSongsPage.processRandomUnverifiedSong();
+  await expect(pages.songEditBasicInfoPage.editedSongHeader).toBeVisible();
+
+  const firstHeaderText = normalizeWhitespace((await pages.songEditBasicInfoPage.editedSongHeader.textContent()) ?? '');
+  const firstSharedSongId = sharedSongIdsInQueue.find(
+    (sharedSongId) =>
+      firstHeaderText ===
+      normalizeWhitespace(`${unverifiedCloudflareSongFixture.artist} - ${visibleTitleBySharedSongId[sharedSongId]}`),
   );
+  expect(firstSharedSongId, 'processing the queue should open one of the seeded unverified songs').toBeDefined();
+
+  const secondSharedSongId = sharedSongIdsInQueue.find((sharedSongId) => sharedSongId !== firstSharedSongId)!;
+
   await expect(pages.songEditSyncLyricsToVideoPage.pageContainer).toBeVisible();
   await pages.songEditSyncLyricsToVideoPage.deleteAdminUnverifiedSong();
 
   await pages.songEditBasicInfoPage.expectEditedSongHeaderToBe(
     unverifiedCloudflareSongFixture.artist,
-    currentVisibleTitle,
+    visibleTitleBySharedSongId[secondSharedSongId],
   );
   await expect(pages.songEditSyncLyricsToVideoPage.pageContainer).toBeVisible();
   await expect
@@ -346,13 +392,15 @@ test('deleting during oldest-first processing redirects to the next unverified s
       });
       const songs = (await response.json()) as Array<{ sharedSongId: string }>;
 
-      return songs.some((song) => song.sharedSongId === oldestUpdatedSharedSongId);
+      return songs.some((song) => song.sharedSongId === firstSharedSongId);
     })
     .toBe(false);
 
   await page.goto('/admin?e2e-test');
-  await pages.adminUnverifiedSongsPage.search(oldestUpdatedVisibleTitle);
-  await expect(pages.adminUnverifiedSongsPage.table.rowWithTitle(oldestUpdatedVisibleTitle)).not.toBeVisible();
+  await pages.adminUnverifiedSongsPage.search(visibleTitleBySharedSongId[firstSharedSongId!]);
+  await expect(
+    pages.adminUnverifiedSongsPage.table.rowWithTitle(visibleTitleBySharedSongId[firstSharedSongId!]),
+  ).not.toBeVisible();
 });
 
 test('deletes an unverified song and refetches the list', async ({ page }) => {

--- a/tests/page-objects/admin-unverified-songs-page.ts
+++ b/tests/page-objects/admin-unverified-songs-page.ts
@@ -28,8 +28,8 @@ export class AdminUnverifiedSongsPagePO {
     return this.page.getByRole('button', { name: 'Logout' });
   }
 
-  public get processOldestUnverifiedButton() {
-    return this.page.getByRole('button', { name: 'Process oldest unverified' });
+  public get processRandomUnverifiedButton() {
+    return this.page.getByRole('button', { name: 'Process random unverified' });
   }
 
   public get adminHeading() {
@@ -62,8 +62,8 @@ export class AdminUnverifiedSongsPagePO {
     await this.logoutButton.click();
   }
 
-  public async processOldestUnverifiedSong() {
-    await this.processOldestUnverifiedButton.click();
+  public async processRandomUnverifiedSong() {
+    await this.processRandomUnverifiedButton.click();
   }
 
   public async expectPasswordStoredInSessionStorage(password: string) {


### PR DESCRIPTION
## Summary
- The admin "validate unverified songs" queue used to always pick the oldest-submitted song, both for the initial "Process unverified" button click and for advancing to the next song after each save/delete.
- `getOldestAdminUnverifiedSong` is replaced with `getRandomAdminUnverifiedSong`, which picks uniformly at random from the remaining candidates (excluding the song currently being processed).
- Button label updated from "Process oldest unverified" to "Process random unverified" to match.

## Test plan
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm oxlint` passes on changed files
- [x] Updated e2e tests in `tests/admin-unverified-songs.spec.ts` and `tests/page-objects/admin-unverified-songs-page.ts` to match the new random-order behavior (queue-advance is still deterministic once only one candidate remains)
- [x] Ran the full `admin-unverified-songs.spec.ts` suite locally against the dev server (chromium + firefox), including 5 repeated runs of the queue-order tests to confirm no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)