### PR TITLE
Fix react/exhaustive-deps violations and promote rule to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,7 +52,7 @@
     "react/no-string-refs": "error",
     "react/no-unescaped-entities": "error",
     "react/rules-of-hooks": "error",
-    "react/exhaustive-deps": "warn",
+    "react/exhaustive-deps": "error",
     "no-only-tests/no-only-tests": "error",
     "react-refresh/only-export-components": [
       "error",

--- a/src/modules/elements/video-player/direct-video.tsx
+++ b/src/modules/elements/video-player/direct-video.tsx
@@ -20,6 +20,11 @@ export default function DirectVideoPlayer({
   const [size, setSize] = useState({ w: width, h: height });
   const [status, setStatus] = useState(VideoState.UNSTARTED);
 
+  // Read the latest status from a ref inside the stable `playerApi` memo, so exposing `getStatus`
+  // doesn't force the memo (and the imperative handle / seek effects) to rebuild on every status change.
+  const statusRef = useRef(status);
+  statusRef.current = status;
+
   useEffect(() => {
     const createCallback = (status: VideoState) => () => setStatus(status);
     const playerRef = player.current;
@@ -49,7 +54,7 @@ export default function DirectVideoPlayer({
   const loadVideoTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playerApi = useMemo<VideoPlayerRef>(
     () => ({
-      getStatus: () => status,
+      getStatus: () => statusRef.current,
       setSize: (w, h) => setSize({ w, h }),
       seekTo: (time: number) => {
         if (player.current) {

--- a/src/modules/game-engine/input/simplified-mic.tsx
+++ b/src/modules/game-engine/input/simplified-mic.tsx
@@ -63,8 +63,8 @@ class SimplifiedMic extends Listener<[number, number]> implements InputInterface
         captureException(e);
         console.error(e);
       }
-    } catch (e: any) {
-      if (e.name !== 'NotAllowedError') {
+    } catch (e) {
+      if (!(e instanceof Error) || e.name !== 'NotAllowedError') {
         captureException(e, { level: 'warning', extra: { message: 'SimplifiedMic.startMonitoring' } });
       }
       console.warn(e);

--- a/src/modules/game-events/hooks.ts
+++ b/src/modules/game-events/hooks.ts
@@ -10,7 +10,7 @@ export function useEventListener<T extends (...args: any[]) => void>(event: Game
     }) as T;
     event.subscribe(subscriber, getLast);
     return () => event.unsubscribe(subscriber);
-  }, [event]);
+  }, [event, getLast]);
 
   return value;
 }
@@ -38,6 +38,7 @@ export function useEventEffect<T extends AnyFunc>(
     eventList.forEach((e) => e.subscribe(effect));
 
     return () => eventList.forEach((e) => e.unsubscribe(effect));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- generic hook: deps are composed from the caller-provided event(s) and `dependencies` and can't be statically verified
   }, [...eventList, effect, ...dependencies]);
 }
 
@@ -50,15 +51,18 @@ export function useEventListenerSelector<S>(
 
   const eventList = Array.isArray(event) ? event : [event];
 
+  /* eslint-disable react-hooks/exhaustive-deps -- generic hook: re-runs on the caller-provided `dependencies` (not a static array literal) */
   useEffect(() => {
     setValue(selector());
   }, dependencies);
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   useEffect(() => {
     const subscriber = () => setValue(selector());
     eventList.forEach((e) => e.subscribe(subscriber));
 
     return () => eventList.forEach((e) => e.unsubscribe(subscriber));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- (re)subscribes only when the event list changes; `selector` is intentionally read latest
   }, [...eventList]);
 
   return value;

--- a/src/modules/hooks/use-base-unit-px.ts
+++ b/src/modules/hooks/use-base-unit-px.ts
@@ -5,5 +5,6 @@ export default function useBaseUnitPx() {
   const { width, height } = useViewportSize();
 
   // return useMemo(() => width * 0.0035, [width, height]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- width/height aren't read directly; they trigger a re-read of the root font size when the viewport changes
   return useMemo(() => parseFloat(getComputedStyle(document.documentElement).fontSize), [width, height]);
 }

--- a/src/modules/hooks/use-effect-debugger.ts
+++ b/src/modules/hooks/use-effect-debugger.ts
@@ -32,5 +32,6 @@ export default function useEffectDebugger(
     console.log('[use-effect-debugger] ', changedDeps);
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- debug wrapper: forwards the caller's effect and deps verbatim
   useEffect(effectHook, dependencies);
 }

--- a/src/modules/hooks/use-fullscreen.ts
+++ b/src/modules/hooks/use-fullscreen.ts
@@ -10,5 +10,6 @@ export default function useFullscreen() {
         document.body.requestFullscreen().catch(console.info);
       }
     } catch (_e) {}
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- auto-enable is intentionally a mount-only action
   }, []);
 }

--- a/src/modules/hooks/use-keyboard-help.ts
+++ b/src/modules/hooks/use-keyboard-help.ts
@@ -20,9 +20,10 @@ export default function useKeyboardHelp(help: HelpEntry, enabled: boolean) {
   // Registers/unregisters presence - only reacts to `enabled` (plus mount/unmount), so becoming
   // active isn't affected by `help` content refreshing while this stays enabled the whole time.
   useEffect(() => {
+    const currentName = name.current;
     if (enabled) {
-      setKeyboard(name.current, helpRef.current);
-      return () => unsetKeyboard(name.current);
+      setKeyboard(currentName, helpRef.current);
+      return () => unsetKeyboard(currentName);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- registration lifecycle is intentionally keyed on `enabled` only
   }, [enabled]);

--- a/src/modules/hooks/use-keyboard-nav.ts
+++ b/src/modules/hooks/use-keyboard-nav.ts
@@ -67,6 +67,8 @@ export default function useKeyboardNav(options: Options = {}, debug = false) {
     // NOTE: `onBackspace` and `additionalHelp` are intentionally excluded — callers pass fresh values
     // each render (a new `() => …` and object literal), so including them would recompute `help`
     // every render and, via updateKeyboard, spin an infinite re-render loop. Their content is static.
+    // `actions` is a stable ref, kept in the list for readability.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentlySelectedActionLabel, actions, backspaceHelp, direction, committedControls],
   );
   useKeyboardHelp(help, enabled);

--- a/src/modules/hooks/use-keyboard.ts
+++ b/src/modules/hooks/use-keyboard.ts
@@ -37,7 +37,7 @@ const cb = (callback?: Callback) => (e: KeyboardEvent) => {
 };
 
 // useHotkeys doesn't seem to be updatable to 4.0 due to https://github.com/JohannesKlauss/react-hotkeys-hook/issues/1074
-export default function useKeyboard(params: Params, enabled = true, deps?: any[]) {
+export default function useKeyboard(params: Params, enabled = true, deps?: unknown[]) {
   useEventEffect(events.remoteKeyboardPressed, (param) => {
     if (enabled) {
       if (param in params) {

--- a/src/modules/hooks/use-memo-debugger.ts
+++ b/src/modules/hooks/use-memo-debugger.ts
@@ -28,6 +28,6 @@ export default function useMemoDebugger<T>(memoHook: () => T, dependencies: unkn
     console.log('[use-memo-debugger] ', changedDeps);
   }
 
-  // eslint-disable-next-line react-compiler/react-compiler
+  // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps -- debug wrapper: forwards the caller's memo fn and deps verbatim
   return useMemo(memoHook, dependencies);
 }

--- a/src/modules/hooks/use-viewport-size.ts
+++ b/src/modules/hooks/use-viewport-size.ts
@@ -23,7 +23,7 @@ export default function useViewportSize() {
     handleResize();
 
     return () => global.removeEventListener('resize', handleResize);
-  }, []);
+  }, [handleResize]);
 
   return { ...windowSize, handleResize };
 }

--- a/src/modules/remote-mic/network/client/hooks/use-server-query.ts
+++ b/src/modules/remote-mic/network/client/hooks/use-server-query.ts
@@ -61,7 +61,7 @@ export function useServerQuery<T>(
     return () => {
       active = false;
     };
-    // queryFnRef is a stable ref and intentionally omitted from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- queryFnRef is a stable ref and intentionally omitted; `deps` is a caller-provided passthrough
   }, [isConnected, ...deps]);
 
   return { data, loading, error, refetch };

--- a/src/modules/remote-mic/network/client/hooks/use-subscription.ts
+++ b/src/modules/remote-mic/network/client/hooks/use-subscription.ts
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { ChannelData, ChannelName, subscriptionManager } from '../subscriptions';
 
 /** Subscribes to a push channel and returns the latest data, or undefined before the first push. */
 export function useSubscription<C extends ChannelName>(channel: C): ChannelData<C> | undefined {
-  const [data, setData] = useState<ChannelData<C> | undefined>(undefined);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => subscriptionManager.subscribe(channel, onStoreChange),
+    [channel],
+  );
+  const getSnapshot = useCallback(() => subscriptionManager.getSnapshot(channel), [channel]);
 
-  useEffect(() => {
-    return subscriptionManager.subscribe(channel, setData);
-  }, [channel]);
-
-  return data;
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/modules/remote-mic/network/client/subscriptions.ts
+++ b/src/modules/remote-mic/network/client/subscriptions.ts
@@ -59,6 +59,12 @@ export class ClientSubscriptionManager {
     return () => this.unsubscribeInternal(channel, callback);
   };
 
+  /** Returns the latest cached data for a channel, or undefined before the first push. Stable
+   * reference between publishes, so it can back `useSyncExternalStore`'s `getSnapshot`. */
+  public getSnapshot = <C extends ChannelName>(channel: C): ChannelData<C> | undefined => {
+    return this.latestData[channel] as ChannelData<C> | undefined;
+  };
+
   private unsubscribeInternal = <C extends ChannelName>(channel: C, callback: ChannelCallback<C>): void => {
     this.callbacks.get(channel)?.delete(callback as ChannelCallback<any>);
     const count = this.subscriberCounts[channel] ?? 0;

--- a/src/modules/songs/stats/hooks.ts
+++ b/src/modules/songs/stats/hooks.ts
@@ -15,6 +15,7 @@ export const useSongStats = (song: Pick<SongPreview, 'artist' | 'title'>) => {
 
   useEffect(() => {
     setSongStats();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refetch stats only when the song key changes
   }, [storageKey]);
 
   useEventEffect(events.songStatStored, setSongStats);

--- a/src/modules/songs/utils/convert-txt-to-song.ts
+++ b/src/modules/songs/utils/convert-txt-to-song.ts
@@ -188,8 +188,8 @@ export default function convertTxtToSong(
     try {
       const linkUrl = new URL(videoLink);
       song.video = linkUrl.searchParams.get('v') || 'Invalid link';
-    } catch (e: any) {
-      song.video = `Invalid link: ${e.message}`;
+    } catch (e) {
+      song.video = `Invalid link: ${e instanceof Error ? e.message : String(e)}`;
     }
   }
 

--- a/src/routes/convert/steps/song-metadata.tsx
+++ b/src/routes/convert/steps/song-metadata.tsx
@@ -62,6 +62,7 @@ export default function SongMetadata(props: Props) {
       console.log('props.data.artistOrigin', defaultArtistOrigin);
       props.onChange({ ...props.data, artistOrigin: defaultArtistOrigin });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only fill the default origin in response to a resolved default or a data change; `props.onChange` is a fresh callback each render
   }, [defaultArtistOrigin, props.data]);
 
   const definedLanguages = useMemo(

--- a/src/routes/exclude-languages/exclude-languages-view.tsx
+++ b/src/routes/exclude-languages/exclude-languages-view.tsx
@@ -66,7 +66,7 @@ function ExcludeLanguagesView({ onClose, closeText }: Props) {
         setExcludedLanguages(toExclude);
       }
     }
-  }, [excludedLanguages, languageList]);
+  }, [excludedLanguages, languageList, setExcludedLanguages]);
 
   const areAllLanguagesExcluded = useMemo(
     () => languageList.every((language) => excludedLanguages?.includes(language.name)),

--- a/src/routes/game/singing/hooks/use-video-player.ts
+++ b/src/routes/game/singing/hooks/use-video-player.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useState } from 'react';
+import { RefObject, useEffect, useRef, useState } from 'react';
 import { milliseconds } from '~/interfaces';
 import { VideoPlayerRef, VideoState } from '~/modules/elements/video-player/index';
 import { FPSCountSetting, InputLagSetting, useSettingValue } from '~/routes/settings/settings-state';
@@ -11,6 +11,11 @@ export const useVideoPlayer = (
   const [currentStatus, setCurrentStatus] = useState(VideoState.UNSTARTED);
   const [inputLag] = useSettingValue(InputLagSetting);
 
+  // Keep the latest onTimeUpdate in a ref so the interval isn't torn down and recreated when the
+  // caller passes a fresh callback each render.
+  const onTimeUpdateRef = useRef(onTimeUpdate);
+  onTimeUpdateRef.current = onTimeUpdate;
+
   useEffect(() => {
     if (!playerRef.current) {
       return;
@@ -21,7 +26,7 @@ export const useVideoPlayer = (
 
         const time = Math.max(0, (await playerRef.current.getCurrentTime()) * 1000 - inputLag);
         setCurrentTime(time);
-        onTimeUpdate?.(time);
+        onTimeUpdateRef.current?.(time);
       }, 1000 / FPSCountSetting.get());
 
       return () => clearInterval(interval);

--- a/src/routes/game/singing/hooks/use-video-player.ts
+++ b/src/routes/game/singing/hooks/use-video-player.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef, useState } from 'react';
+import { RefObject, useEffect, useEffectEvent, useState } from 'react';
 import { milliseconds } from '~/interfaces';
 import { VideoPlayerRef, VideoState } from '~/modules/elements/video-player/index';
 import { FPSCountSetting, InputLagSetting, useSettingValue } from '~/routes/settings/settings-state';
@@ -11,10 +11,11 @@ export const useVideoPlayer = (
   const [currentStatus, setCurrentStatus] = useState(VideoState.UNSTARTED);
   const [inputLag] = useSettingValue(InputLagSetting);
 
-  // Keep the latest onTimeUpdate in a ref so the interval isn't torn down and recreated when the
-  // caller passes a fresh callback each render.
-  const onTimeUpdateRef = useRef(onTimeUpdate);
-  onTimeUpdateRef.current = onTimeUpdate;
+  // Effect Event: always calls the latest onTimeUpdate without making it a dependency of the
+  // interval effect, so a fresh callback each render doesn't tear down and recreate the interval.
+  const onTimeUpdateEvent = useEffectEvent((time: milliseconds) => {
+    onTimeUpdate?.(time);
+  });
 
   useEffect(() => {
     if (!playerRef.current) {
@@ -26,7 +27,7 @@ export const useVideoPlayer = (
 
         const time = Math.max(0, (await playerRef.current.getCurrentTime()) * 1000 - inputLag);
         setCurrentTime(time);
-        onTimeUpdateRef.current?.(time);
+        onTimeUpdateEvent(time);
       }, 1000 / FPSCountSetting.get());
 
       return () => clearInterval(interval);

--- a/src/routes/game/singing/post-game/views/results/camera-roll-placeholder.tsx
+++ b/src/routes/game/singing/post-game/views/results/camera-roll-placeholder.tsx
@@ -23,7 +23,7 @@ export const CameraRollPlaceholder = ({ register, onConfirm, loading }: Props) =
         }
       });
     }
-  }, [loading]);
+  }, [loading, permissionStatus]);
 
   return (
     <div className={`typography flex aspect-4/3 flex-col items-end`}>

--- a/src/routes/game/singing/wait-for-readiness.tsx
+++ b/src/routes/game/singing/wait-for-readiness.tsx
@@ -53,6 +53,7 @@ function WaitForReadiness({ onFinish }: Props) {
       await sleep(1000);
       onFinish();
     })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the readiness/autostart sequence runs once on mount
   }, []);
 
   const playerStatuses = players.map(([deviceId, name, player]) => ({

--- a/src/routes/remote-mic/components/confrim-wifi-modal.tsx
+++ b/src/routes/remote-mic/components/confrim-wifi-modal.tsx
@@ -37,6 +37,7 @@ export default function ConfirmWifiModal({ onClose }: Props) {
         return () => navigator?.connection?.removeEventListener?.('change', onChange);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- runs the Wi-Fi connection check once on mount
   }, []);
 
   return (

--- a/src/routes/remote-mic/components/player-number-circle.tsx
+++ b/src/routes/remote-mic/components/player-number-circle.tsx
@@ -13,7 +13,7 @@ export default function PlayerNumberCircle({ number, ...restProps }: Props) {
   const forceUpdate = useUpdate();
   useEffect(() => {
     forceUpdate();
-  }, [style]);
+  }, [style, forceUpdate]);
 
   return (
     <PlayerColorCircle

--- a/src/routes/remote-mic/panels/microphone/connection-wizard/step-enter-details.tsx
+++ b/src/routes/remote-mic/panels/microphone/connection-wizard/step-enter-details.tsx
@@ -58,6 +58,7 @@ export default function StepEnterDetails({ roomId, onConnect, connectionStatus, 
 
   useEffect(() => {
     focusNextInput(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- focus the first empty input once on mount
   }, []);
 
   const shouldShowError = connectionStatus === 'error' && !errorReset;

--- a/src/routes/remote-mic/panels/microphone/ping.tsx
+++ b/src/routes/remote-mic/panels/microphone/ping.tsx
@@ -8,11 +8,12 @@ function Ping() {
   useEffect(() => {
     const interval = setInterval(() => {
       const now = getPingTime();
-      if (RemoteMicClient.pinging && now - RemoteMicClient.pingStart > latency) {
-        setLatency(now - RemoteMicClient.pingStart);
-      } else {
-        setLatency(RemoteMicClient.latency);
-      }
+      setLatency((current) => {
+        if (RemoteMicClient.pinging && now - RemoteMicClient.pingStart > current) {
+          return now - RemoteMicClient.pingStart;
+        }
+        return RemoteMicClient.latency;
+      });
     }, 333);
 
     return () => {

--- a/src/routes/remote-mic/panels/remote-song-list/use-my-song-list.ts
+++ b/src/routes/remote-mic/panels/remote-song-list/use-my-song-list.ts
@@ -19,7 +19,7 @@ export const useMySongList = () => {
         void serverRpc.songs.sendMyList({ added: [songId] });
       }
     },
-    [savedSongList],
+    [savedSongList, setSavedSongList],
   );
 
   return { savedSongList, toggleSong };

--- a/src/routes/select-input/hooks/use-player-number-preset.ts
+++ b/src/routes/select-input/hooks/use-player-number-preset.ts
@@ -20,5 +20,5 @@ export default function usePlayerNumberPreset(targetPlayerCount: number, maxPlay
         PlayersManager.addPlayer(availableNumbers.shift()! as 0 | 1 | 2 | 3);
       }
     }
-  }, []);
+  }, [targetPlayerCount, maxPlayerCount]);
 }

--- a/src/routes/select-input/variants/advanced.tsx
+++ b/src/routes/select-input/variants/advanced.tsx
@@ -32,6 +32,7 @@ function Advanced(props: Props) {
 
   useEffect(() => {
     props.onSetupComplete(status === 'accepted');
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- report setup completion when mic permission status changes
   }, [status]);
 
   useRemoteMicAutoselect();

--- a/src/routes/select-input/variants/different-mics.tsx
+++ b/src/routes/select-input/variants/different-mics.tsx
@@ -27,6 +27,7 @@ function DifferentMics(props: Props) {
 
   useEffect(() => {
     props.onSetupComplete(status === 'accepted');
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- report setup completion when mic permission status changes
   }, [status]);
 
   useEffect(() => {

--- a/src/routes/select-input/variants/remote-mics.tsx
+++ b/src/routes/select-input/variants/remote-mics.tsx
@@ -49,6 +49,7 @@ function RemoteMics(props: Props) {
 
   useEffect(() => {
     props.onSetupComplete(isComplete);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- report setup completion when the players' completeness changes
   }, [isComplete]);
 
   return (

--- a/src/routes/select-input/variants/sing-star-mics.tsx
+++ b/src/routes/select-input/variants/sing-star-mics.tsx
@@ -79,6 +79,7 @@ function SingStarMics(props: Props) {
 
   useEffect(() => {
     props.onSetupComplete(isSetup);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- report setup completion when the SingStar setup state changes
   }, [isSetup]);
 
   useEffect(() => {

--- a/src/routes/select-input/variants/skip.tsx
+++ b/src/routes/select-input/variants/skip.tsx
@@ -13,6 +13,7 @@ interface Props {
 function Skip(props: Props) {
   useEffect(() => {
     props.onSave();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- save once on mount
   }, []);
 
   return null;

--- a/src/routes/sing-a-song/song-selection/components/custom-virtualization.tsx
+++ b/src/routes/sing-a-song/song-selection/components/custom-virtualization.tsx
@@ -102,25 +102,26 @@ export function CustomVirtualization<T>(props: Props<T>) {
   const [[rangeFrom, rangeTo], setItemsRange] = useState(() => computeVisibleItemsRange(0));
 
   useLayoutEffect(() => {
-    if (viewportElementRef.current) {
+    const viewport = viewportElementRef.current;
+    if (viewport) {
       // if the new scrollTop would cause different changes the range to render, update it
       const onScroll = () => {
-        const newItemsRange = computeVisibleItemsRange(viewportElementRef.current?.scrollTop ?? 0);
+        const newItemsRange = computeVisibleItemsRange(viewport.scrollTop ?? 0);
         if (rangeFrom !== newItemsRange[0] || rangeTo !== newItemsRange[1]) {
           setItemsRange(newItemsRange);
         }
       };
 
-      viewportElementRef.current.addEventListener('scroll', onScroll);
+      viewport.addEventListener('scroll', onScroll);
 
-      if (viewportElementRef.current.scrollTop > totalHeight) {
-        viewportElementRef.current.scrollTo({ top: 0 });
+      if (viewport.scrollTop > totalHeight) {
+        viewport.scrollTo({ top: 0 });
       }
 
       onScroll(); // todo determine if this is needed?
 
       return () => {
-        viewportElementRef.current?.removeEventListener('scroll', onScroll);
+        viewport.removeEventListener('scroll', onScroll);
       };
     }
   }, [rangeFrom, rangeTo, computeVisibleItemsRange, totalHeight]);

--- a/src/routes/sing-a-song/song-selection/components/toolbar/search-bar.tsx
+++ b/src/routes/sing-a-song/song-selection/components/toolbar/search-bar.tsx
@@ -62,10 +62,15 @@ export default function SearchBar({
 
   const expanded = collapseSearch && mobileSearchVisible;
 
+  // Keep the latest callback in a ref so the layout effect fires only when `expanded` changes,
+  // not whenever the parent passes a fresh `onExpandedChange`.
+  const onExpandedChangeRef = useRef(onExpandedChange);
+  onExpandedChangeRef.current = onExpandedChange;
+
   // useLayoutEffect so Toolbar hides random+playlists in the same paint frame SearchBar expands,
   // preventing a layout shift where both the expanding input and other buttons are briefly visible.
   useLayoutEffect(() => {
-    onExpandedChange?.(expanded);
+    onExpandedChangeRef.current?.(expanded);
   }, [expanded]);
 
   useHotkeys('down', () => searchInput.current?.element?.blur(), { enabled: isFocused, enableOnTags: ['INPUT'] });
@@ -87,9 +92,9 @@ export default function SearchBar({
 
   const onRemoteSearch = useCallback(
     (search: string) => {
-      if (keyboardControl) setSearch(search);
+      if (keyboardControl) setFilters((current) => ({ ...current, search }));
     },
-    [keyboardControl],
+    [keyboardControl, setFilters],
   );
   useEventEffect(events.remoteSongSearch, onRemoteSearch);
 

--- a/src/routes/sing-a-song/song-selection/components/toolbar/search-bar.tsx
+++ b/src/routes/sing-a-song/song-selection/components/toolbar/search-bar.tsx
@@ -6,6 +6,7 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useRef,
   useState,
@@ -62,15 +63,16 @@ export default function SearchBar({
 
   const expanded = collapseSearch && mobileSearchVisible;
 
-  // Keep the latest callback in a ref so the layout effect fires only when `expanded` changes,
-  // not whenever the parent passes a fresh `onExpandedChange`.
-  const onExpandedChangeRef = useRef(onExpandedChange);
-  onExpandedChangeRef.current = onExpandedChange;
+  // Effect Event: notify the parent with the latest callback without making it a dependency, so the
+  // layout effect fires only when `expanded` changes, not whenever a fresh `onExpandedChange` arrives.
+  const notifyExpandedChange = useEffectEvent((value: boolean) => {
+    onExpandedChange?.(value);
+  });
 
   // useLayoutEffect so Toolbar hides random+playlists in the same paint frame SearchBar expands,
   // preventing a layout shift where both the expanding input and other buttons are briefly visible.
   useLayoutEffect(() => {
-    onExpandedChangeRef.current?.(expanded);
+    notifyExpandedChange(expanded);
   }, [expanded]);
 
   useHotkeys('down', () => searchInput.current?.element?.blur(), { enabled: isFocused, enableOnTags: ['INPUT'] });

--- a/src/routes/sing-a-song/song-selection/hooks/use-recommended-songs.ts
+++ b/src/routes/sing-a-song/song-selection/hooks/use-recommended-songs.ts
@@ -54,7 +54,7 @@ export default function useRecommendedSongs(songs: SongPreview[]) {
     return {
       popular: [...new Set([...actuallySungSongs, ...finalPopularSongs, ...songsToAdd, ...recentlyUpdatedSongs])],
     };
-  }, [excludedLanguages, loading, popularSongs.value, songs, sungSongs.value]);
+  }, [excludedLanguages, loading, popularSongs.value, songs, sungSongs.value, recentlyUpdatedSongs]);
 
   const defaultValue = useMemo(() => ({ popular: [] }), []);
 

--- a/src/routes/sing-a-song/song-selection/hooks/use-song-list-filter.ts
+++ b/src/routes/sing-a-song/song-selection/hooks/use-song-list-filter.ts
@@ -167,7 +167,6 @@ export const useSongListFilter = (
   }, [selectedPlaylist]);
 
   const deferredFilters = useDeferredValue(filters);
-  const isSearchApplied = !!deferredFilters.search;
 
   const filteredList = useMemo(
     () =>
@@ -177,7 +176,7 @@ export const useSongListFilter = (
         excludeLanguages: excludedLanguages ?? [],
         additionalSongs: additionalSong ? [additionalSong] : [],
       }),
-    [list, deferredFilters, excludedLanguages, playlist, additionalSong, isSearchApplied],
+    [list, deferredFilters, excludedLanguages, playlist, additionalSong],
   );
 
   return {

--- a/src/routes/sing-a-song/song-selection/hooks/use-song-selection-keyboard-navigation.ts
+++ b/src/routes/sing-a-song/song-selection/hooks/use-song-selection-keyboard-navigation.ts
@@ -141,6 +141,7 @@ export const useSongSelectionKeyboardNavigation = (
         setBlockBack(false);
       };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the search transition only; adding `previousSearch` would re-run the effect a render later and clear the block prematurely
   }, [appliedFilters.search]);
 
   const handleBackspace = () => {
@@ -241,19 +242,17 @@ export const useSongSelectionKeyboardNavigation = (
   );
   useKeyboardHelp(help, enabled);
 
-  const closePlaylist = useCallback(
-    (newLeavingKey?: 'left' | 'right') => {
-      setShowPlaylistsState([false, newLeavingKey ?? null]);
-      // if (leavingKey === 'right') navigateHorizontally(1);
-    },
-    [setShowPlaylistsState, navigateHorizontally, groupedSongs, cursorPosition],
-  );
+  const closePlaylist = useCallback((newLeavingKey?: 'left' | 'right') => {
+    setShowPlaylistsState([false, newLeavingKey ?? null]);
+    // if (leavingKey === 'right') navigateHorizontally(1);
+  }, []);
 
   useLayoutEffect(() => {
     const [previousShowFilters, enteringKey] = previousPlaylistsState;
     if (previousShowFilters && !arePlaylistsVisible) {
       if (enteringKey === leavingKey) navigateHorizontally(leavingKey === 'right' ? 1 : -1);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the playlist-visibility/cursor transition; `navigateHorizontally` is recreated each render and `previousPlaylistsState` is read intentionally
   }, [arePlaylistsVisible, leavingKey, isAtFirstColumn, isAtLastColumn, ...cursorPosition]);
 
   return [selectedSongId, moveToSong, arePlaylistsVisible, closePlaylist, randomSong] as const;

--- a/src/routes/sing-a-song/song-selection/hooks/use-unverified-songs-search.ts
+++ b/src/routes/sing-a-song/song-selection/hooks/use-unverified-songs-search.ts
@@ -25,14 +25,12 @@ export default function useUnverifiedSongsSearch({
 
   useLayoutEffect(() => {
     let isActive = true;
+    // Use functional updaters so this effect doesn't depend on `unverifiedSongs`/`isFetching`
+    // (which would re-run it right after a successful fetch and loop). Returning the same value
+    // bails out of the state update, matching the previous guarded behaviour.
     const clearResults = () => {
-      if (unverifiedSongs.length > 0) {
-        setUnverifiedSongs([]);
-      }
-
-      if (isFetching) {
-        setIsFetching(false);
-      }
+      setUnverifiedSongs((current) => (current.length > 0 ? [] : current));
+      setIsFetching((current) => (current ? false : current));
     };
 
     if (!shouldFetchUnverifiedSongs || !debouncedSearch) {

--- a/src/routes/sing-a-song/song-selection/song-selection.tsx
+++ b/src/routes/sing-a-song/song-selection/song-selection.tsx
@@ -152,6 +152,7 @@ export default function SongSelection({ onSongSelected, preselectedSong }: Props
     if (!isLoading) {
       list.current?.scrollToSongInGroup(focusedSong, 'auto');
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- recalculates layout on width/playlist/search changes; `focusedSong` is read latest and has its own scroll effect above
   }, [width, selectedPlaylist, filters.search, isLoading, handleResize]);
 
   const navigate = useSmoothNavigate();

--- a/src/stories/game-overlay.stories.tsx
+++ b/src/stories/game-overlay.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentProps, useEffect, useMemo, useRef } from 'react';
 import { useUpdate } from 'react-use';
 import { ValuesType } from 'utility-types';
 import { GAME_MODE, SingSetup } from '~/interfaces';
-import { VideoState } from '~/modules/elements/video-player/index';
+import { VideoPlayerRef, VideoState } from '~/modules/elements/video-player/index';
 import CanvasDrawing from '~/modules/game-engine/drawing/index';
 import ParticleManager from '~/modules/game-engine/drawing/particle-manager';
 import GameState from '~/modules/game-engine/game-state/game-state';
@@ -93,7 +93,7 @@ const Template: StoryFn<StoryArgs> = (args) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- storybook template: redraw only when the progress arg changes
   }, [args.progress]);
 
-  const videoPlayerRef = useRef<any>(null);
+  const videoPlayerRef = useRef<VideoPlayerRef | null>(null);
 
   return (
     <div style={{ position: 'relative', width: 1280, height: 720 }}>

--- a/src/stories/game-overlay.stories.tsx
+++ b/src/stories/game-overlay.stories.tsx
@@ -67,6 +67,7 @@ const Template: StoryFn<StoryArgs> = (args) => {
     GameState.setSingSetup(setup);
 
     return setup;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- storybook template: rebuild the setup only when the story args change
   }, [args.tolerance, args.playerNum, args.gameMode]);
 
   useEffect(() => {
@@ -89,6 +90,7 @@ const Template: StoryFn<StoryArgs> = (args) => {
       ParticleManager.clearAll();
     }, 100);
     update();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- storybook template: redraw only when the progress arg changes
   }, [args.progress]);
 
   const videoPlayerRef = useRef<any>(null);

--- a/src/stories/player.stories.tsx
+++ b/src/stories/player.stories.tsx
@@ -55,6 +55,7 @@ const Template: StoryFn<StoryArgs> = (args) => {
     GameState.resetSingSetup();
     GameState.setSingSetup(singSetup);
     GameState.setSong(song);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- storybook template: reset game state only when the story args change
   }, [args.tolerance, args.playerNum, args.gameMode]);
 
   const ref = useRef<PlayerRef | null>(null);


### PR DESCRIPTION
## What

Promotes `react/exhaustive-deps` from `warn` to `error` in `.oxlintrc.json` and resolves all 53 violations across 36 files.

## How

Each violation was handled to **preserve existing runtime behaviour**, not just to silence the linter:

**Genuine missing dependency added** (stable setters/refs, memoized values, or mount-time params — no behavior change):
`use-viewport-size`, `player-number-circle`, `use-my-song-list`, `exclude-languages-view`, `use-recommended-songs`, `use-player-number-preset`, `game-events` (`useEventListener`), `camera-roll-placeholder`.

**Reworked to keep behaviour while dropping the flagged dep:**
- `use-video-player` / `search-bar` — read the latest callback from a ref so the interval / layout effect isn't recreated every render.
- `direct-video` — expose `getStatus` through a status ref so the imperative-handle memo stays stable.
- `ping` / `use-unverified-songs-search` — functional `setState` to remove state reads from the dep list (also fixes a would-be refetch loop and a stale-closure comparison).
- `use-keyboard-help` / `custom-virtualization` — copy the ref value to a local before the cleanup closure.
- `search-bar` — inline the stable `setFilters` dispatch in the remote-search callback.

**Unnecessary dependency removed:** `use-song-list-filter` (`isSearchApplied`), `use-song-selection-keyboard-navigation` (`closePlaylist`).

**Justified `eslint-disable` comment** where including the dep would break behaviour — mount-only effects, generic passthrough-deps library hooks (`useEventEffect`, `useEventListenerSelector`, `use-effect-debugger`, `use-memo-debugger`, `use-server-query`), intentionally keyed effects (`use-keyboard-nav`, `use-song-selection-keyboard-navigation`), and Storybook templates.

## Testing

- `pnpm type-check` ✅
- `pnpm lint` — 0 errors, 0 `exhaustive-deps` (pre-existing `no-explicit-any` warnings untouched) ✅
- Unit tests: 154 passing ✅
- E2E sweep on chromium covering every touched area — gameplay/video player, keyboard navigation, song-list virtualization & search, select-input variants, language selection, convert, and remote-mic flows. All green (remote-mic specs show the usual WebRTC connection flakiness that resolves on retry, as CI already handles with `retries: 1`). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback state reporting and ensured imperative controls always see the latest status.
  * Updated video time updates to keep callbacks current without resetting unnecessarily.
  * Fixed camera feed initialization when permissions change.
  * Corrected refresh behavior for excluded languages, recommended songs, and search/filtering results.
  * Refined remote-microphone updates, including latency polling and more consistent real-time subscription behavior.
* **Chores**
  * Tightened hook dependency linting and clarified several intentionally-exempt effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->