### PR TITLE
Add focus-neighbour glow effect to menus

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -314,6 +314,55 @@ code {
   }
 }
 
+/*
+  Menu.tsx: the item directly above/below the focused one gets a slight glow on the edge touching
+  it, as if the active color were bleeding out of the focused item. Both directions stay mounted at
+  all times and only their opacity toggles, so the glow fades in/out smoothly as focus moves instead
+  of popping in/out instantly.
+
+  Which item is the nearest FOCUSABLE neighbour (skipping dividers, headers, disabled items, …) is
+  exactly what useKeyboardNav already tracks via its ordered registration list — `register()`
+  (use-keyboard-nav.ts) computes it once in JS and stamps `data-next-focusable` / `data-previous-
+  focusable` directly on the right item's own root element (the actual button), instead of this CSS
+  trying to rediscover "focusable" from the DOM shape.
+
+  That attribute always lands on the real interactive element itself — `MenuButton` may wrap it in
+  an extra div for `info` text, but the wrapping div never carries these attributes, only the button
+  does. So this targets `[data-focused]` etc. as a descendant (not `>`, a direct child) to reach past
+  that wrapper, which also means the glow box is sized to the button alone and never bleeds onto the
+  info text next to it.
+*/
+.menu-neighbour-glow [data-focused] {
+  position: relative;
+}
+
+.menu-neighbour-glow [data-focused]::before,
+.menu-neighbour-glow [data-focused]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 250ms ease-in-out;
+}
+
+.menu-neighbour-glow [data-focused]::before {
+  background-image: linear-gradient(to bottom, rgb(255 165 0 / 16%), transparent 55%);
+}
+
+.menu-neighbour-glow [data-focused]::after {
+  background-image: linear-gradient(to top, rgb(255 165 0 / 16%), transparent 55%);
+}
+
+.menu-neighbour-glow [data-next-focusable='true']::before {
+  opacity: 1;
+}
+
+.menu-neighbour-glow [data-previous-focusable='true']::after {
+  opacity: 1;
+}
+
 h1 {
   font-size: 2.5rem;
 }

--- a/src/modules/elements/akui/menu.tsx
+++ b/src/modules/elements/akui/menu.tsx
@@ -4,10 +4,15 @@ import { twc } from 'react-twc';
 import { MenuButton } from '~/modules/elements/akui/menu/menu-button';
 import Box from '~/modules/elements/akui/primitives/box';
 import Typography from '~/modules/elements/akui/primitives/typography';
+import isE2E from '~/modules/utils/is-e2-e';
 
-const MenuContainer = twc(
-  Box,
-)`pointer-events-auto w-[100vw] items-stretch rounded-none [view-transition-name:menu-container] sm:max-w-[45rem] md:rounded-xl lg:max-w-[45rem] 2xl:max-w-[60rem]`;
+// Styling lives in the `menu-neighbour-glow` rules in index.css (needs a real CSS transition to
+// fade in/out, which arbitrary Tailwind variants can't express cleanly). Skipped in e2e so it
+// doesn't chase the same non-determinism the base focus styles avoid (see button.tsx).
+const MenuContainer = twc(Box)(() => [
+  'pointer-events-auto w-[100vw] items-stretch rounded-none [view-transition-name:menu-container] sm:max-w-[45rem] md:rounded-xl lg:max-w-[45rem] 2xl:max-w-[60rem]',
+  !isE2E() && 'menu-neighbour-glow',
+]);
 
 export const MenuHelpText = twc(Typography)`text-md mobile:text-xs`;
 const MenuSubHeader = twc(Typography)`text-lg`;

--- a/src/modules/hooks/use-keyboard-nav.ts
+++ b/src/modules/hooks/use-keyboard-nav.ts
@@ -119,6 +119,17 @@ export default function useKeyboardNav(options: Options = {}, debug = false) {
 
   let defaultSelection = '';
 
+  // The nearest registered (non-disabled, non-decorative) neighbours of the current selection, by
+  // registration order — not the wrap-around order `handleNavigation` uses, since a menu's "glow"
+  // effect (Menu.tsx / index.css `menu-neighbour-glow`) shouldn't visually link the last item back
+  // to the first. `null` at either end of the list, same as `elementList.current`'s own boundaries.
+  const selectedIndex = currentlySelected ? elementList.current.indexOf(currentlySelected) : -1;
+  const previousFocusableName = selectedIndex > 0 ? elementList.current[selectedIndex - 1] : null;
+  const nextFocusableName =
+    selectedIndex !== -1 && selectedIndex < elementList.current.length - 1
+      ? elementList.current[selectedIndex + 1]
+      : null;
+
   const register = (
     name: string,
     onActive: (e?: Event) => void,
@@ -156,7 +167,14 @@ export default function useKeyboardNav(options: Options = {}, debug = false) {
       [propName]: onActive,
       $keyboardNavigationChangeFocus: handleNavigation,
       'data-test': name,
-      ...(enabled ? { 'data-focused': focused, 'data-e2e-focused': focused } : {}),
+      ...(enabled
+        ? {
+            'data-focused': focused,
+            'data-e2e-focused': focused,
+            'data-next-focusable': name === nextFocusableName,
+            'data-previous-focusable': name === previousFocusableName,
+          }
+        : {}),
     };
   };
 


### PR DESCRIPTION
## Summary
- Menu items directly above/below the currently focused item get a slight, animated glow bleeding out of the focused item's edge — CSS-only, opacity-transitioned so it fades in/out smoothly as focus moves.
- `useKeyboardNav` computes the true nearest focusable neighbour from its own registration order (`register()`'s ordered element list), so dividers, headers, disabled items, and info-wrapped items are all handled correctly — the effect never lights up something the user can't actually navigate to.
- Scoped to `Menu` via a dedicated `menu-neighbour-glow` class so it never affects buttons used outside of menus, and skipped under `isE2E()` to match how the existing base focus styling is already suppressed for e2e determinism.

## Test plan
- [x] Verified in Storybook (`AKUI/Menu` story) that only the immediate neighbours of the focused item glow, with the correct edge/direction on each side.
- [x] Verified against a `useKeyboardNav`-driven menu replicating a real settings-style layout (switches, buttons with `info` text, `<hr>` dividers) that keyboard navigation correctly highlights the nearest focusable neighbour on both sides, skipping over dividers and non-focusable elements, and that the glow box is confined to the button itself (never bleeding onto adjacent info text).
- [x] `pnpm type-check`, `pnpm lint`, and pre-commit hooks (tests, knip) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)