### PR TITLE
Comment on PR when E2E tests fail

### DIFF
--- a/.github/templates/commit-and-comment-snapshots/action.yml
+++ b/.github/templates/commit-and-comment-snapshots/action.yml
@@ -62,10 +62,10 @@ runs:
       env:
         BASE_URL: ${{ steps.deploy-visual-diff.outputs.deployment-alias-url }}
       run: pnpm visual-diff:comment
-    # A single "sticky" comment per job (identified by a hidden marker) is
-    # upserted so only the latest gallery is ever shown, and removed once the
-    # snapshots are back in sync - rather than stacking a new comment per run.
-    - name: Upsert or remove visual diff comment
+    # A single comment per job (identified by a hidden marker) is kept: any prior one is
+    # deleted and replaced with a fresh comment (not edited in place) so the PR author gets
+    # a notification, and removed entirely once the snapshots are back in sync.
+    - name: Replace or remove visual diff comment
       uses: actions/github-script@v8
       env:
         COMMENT_BODY: ${{ inputs.comment-body }}
@@ -105,7 +105,6 @@ runs:
           const body = `${process.env.COMMENT_BODY}\n\n[${process.env.COMMENT_LINK_TEXT}](${runUrl})${gallery}\n\n${marker}`;
 
           if (existing) {
-            await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-          } else {
-            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
           }
+          await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/.github/workflows/ci-improvement.yml
+++ b/.github/workflows/ci-improvement.yml
@@ -74,10 +74,14 @@ jobs:
           grepInvert: '@visual'
   e2e-tests-add-summary:
     runs-on: ubuntu-latest
-    if: ${{ failure() }}
+    if: always() # needs to run on success too, to clean up a stale failure comment from a previous run
     needs: e2e-tests-run
+    permissions:
+      pull-requests: write # allows commenting on a PR
     steps:
-      - uses: actions/github-script@v8
+      - name: Write job summary
+        if: needs.e2e-tests-run.result == 'failure'
+        uses: actions/github-script@v8
         with:
           script: |
             core.summary.addRaw(`
@@ -87,6 +91,47 @@ jobs:
             | **URL**: | 	https://${{ github.run_id }}.allkaraoke-party-tests-results.pages.dev |
             `
             ).write();
+      # A single comment (identified by a hidden marker) is kept: any prior one is deleted and
+      # replaced with a fresh comment (not edited in place) so the PR author gets a
+      # notification, and removed entirely once tests are green again.
+      - name: Replace or remove PR comment about E2E failures
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          E2E_RESULT: ${{ needs.e2e-tests-run.result }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const marker = '<!-- e2e-test-summary -->';
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (process.env.E2E_RESULT === 'success') {
+              if (existing) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+              }
+              return;
+            }
+
+            if (process.env.E2E_RESULT !== 'failure') {
+              return; // skipped/cancelled: leave any existing comment as-is, nothing new to report
+            }
+
+            const reportUrl = `https://${context.runId}.allkaraoke-party-tests-results.pages.dev`;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = `## ❌ E2E tests failed\n\n- [Test report](${reportUrl})\n- [Workflow run](${runUrl})\n\n${marker}`;
+
+            if (existing) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+            }
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
 
   ct-tests-run:
     container:


### PR DESCRIPTION
## Summary
- `e2e-tests-add-summary` now runs on every conclusion (not just failure) and posts a PR comment with links to the test report and workflow run whenever the E2E job fails
- The comment is removed once tests pass again, even if the failure happened on a previous run
- Both this new comment and the existing visual-diff snapshot comment now delete-and-recreate instead of editing in place, so a repeat failure actually triggers a GitHub notification for the PR author instead of silently updating a comment they may have already dismissed

## Test plan
- [ ] Validate YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-improvement.yml'))"`) — done locally
- [ ] Open a PR against this branch with a failing E2E test and confirm a comment appears with working report/run links
- [ ] Push a fix and confirm the comment is deleted
- [ ] Confirm the visual-diff comment on a CT/VR snapshot change still appears/disappears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request test-result comments to prevent stale failure reports.
  * Existing visual diff comments are now replaced with fresh updates when changes are detected.
  * Outdated comments are removed when visual or end-to-end checks pass.
  * End-to-end failure comments now include links to the test report and workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->