### PR TITLE
mirror exclude language screen

### DIFF
--- a/src/modules/elements/akui/icon.tsx
+++ b/src/modules/elements/akui/icon.tsx
@@ -73,6 +73,7 @@ export type IconName =
   | 'mdi:circle'
   | 'mdi:qrcode-scan'
   | 'mdi:warning'
+  | 'ic:baseline-language'
   | 'mdi:wifi';
 
 /**

--- a/src/routes/exclude-languages/exclude-languages-view.tsx
+++ b/src/routes/exclude-languages/exclude-languages-view.tsx
@@ -3,13 +3,13 @@ import { useEffect, useMemo } from 'react';
 import CountUp from 'react-countup';
 import { twc } from 'react-twc';
 
-import { Checkbox } from '~/modules/elements/akui/checkbox';
 import { Icon } from '~/modules/elements/akui/icon';
 import { Menu } from '~/modules/elements/akui/menu';
 import { Flag } from '~/modules/elements/flag';
 import { MenuButton } from '~/modules/elements/menu';
 import MenuWithLogo from '~/modules/elements/menu-with-logo';
-import useKeyboardNav from '~/modules/hooks/use-keyboard-nav';
+import { NavButton, NavCheckbox } from '~/modules/elements/nav-controls';
+import useKeyboardNav, { KeyboardNavContext } from '~/modules/hooks/use-keyboard-nav';
 import { useLanguageList } from '~/modules/songs/hooks/use-language-list';
 import useSongIndex from '~/modules/songs/hooks/use-song-index';
 import isE2E from '~/modules/utils/is-e2-e';
@@ -24,7 +24,7 @@ interface Props {
 const MIN_SONGS_COUNT = isE2E() ? 0 : 20;
 
 function ExcludeLanguagesView({ onClose, closeText }: Props) {
-  const { register } = useKeyboardNav({ onBackspace: onClose });
+  const { register } = useKeyboardNav({ onBackspace: onClose, title: 'Select Song Languages' });
 
   const [excludedLanguages, setExcludedLanguages] = useSettingValue(ExcludedLanguagesSetting);
   const { data, isLoading } = useSongIndex();
@@ -84,67 +84,73 @@ function ExcludeLanguagesView({ onClose, closeText }: Props) {
   return (
     <MenuWithLogo>
       <Menu.Header>Select Song Languages</Menu.Header>
-      <>
-        {isLoading &&
-          new Array(6).fill(0).map((_, i) => (
-            <Skeleton variant="rectangular" width="100%" height="100px" key={i}>
-              <LanguageEntry data-excluded focused={false}>
-                <Flag language={['English']} />
-              </LanguageEntry>
-            </Skeleton>
-          ))}
-        {languageList.map(({ name, count }) => {
-          const excluded = excludedLanguages?.includes(name) ?? false;
-          return (
-            <Checkbox
-              size="regular"
-              className={`relative transition-all ${excluded ? 'opacity-50' : 'opacity-100'} duration-300`}
-              checked={!excluded}
-              key={name}
-              data-excluded={excluded}
-              {...register(`lang-${name}`, () => toggleLanguage(name))}>
-              <span>
-                <LanguageName>{name}</LanguageName> ({count} songs)
-              </span>
-              <div
-                className={`absolute top-[1px] right-[1px] bottom-[1px] w-20 transition-all md:w-30 ${excluded ? 'grayscale-75' : 'grayscale-0'}`}>
-                <Flag language={[name]} className="h-full w-full rounded-r-xl object-cover" />
-              </div>
-            </Checkbox>
-          );
-        })}
-        {otherSongCount > 0 && (
-          <Menu.HelpText className="text-right">
-            …and <strong>{otherSongCount} songs</strong> in other languages
-          </Menu.HelpText>
-        )}
-      </>
-      <Menu.HelpText>
-        You can always update the selection in <strong>Manage Songs</strong> menu
-      </Menu.HelpText>
-      <NextButtonContainer>
-        <MenuButton
-          {...register('close-exclude-languages', onClose, undefined, true, {
-            disabled: areAllLanguagesExcluded || isLoading,
-          })}>
-          {closeText}
-        </MenuButton>
-        <Menu.HelpText className="text-right">
-          The list will contain{' '}
-          <strong>
-            <CountUp duration={1} preserveValue end={songCount + otherSongCount} />
-          </strong>{' '}
-          songs
+      <KeyboardNavContext value={register}>
+        <>
+          {isLoading &&
+            new Array(6).fill(0).map((_, i) => (
+              <Skeleton variant="rectangular" width="100%" height="100px" key={i}>
+                <LanguageEntry data-excluded focused={false}>
+                  <Flag language={['English']} />
+                </LanguageEntry>
+              </Skeleton>
+            ))}
+          {languageList.map(({ name, count }) => {
+            const excluded = excludedLanguages?.includes(name) ?? false;
+            return (
+              <NavCheckbox
+                size="regular"
+                className={`relative transition-all ${excluded ? 'opacity-50' : 'opacity-100'} duration-300`}
+                checked={!excluded}
+                key={name}
+                data-excluded={excluded}
+                name={`lang-${name}`}
+                label={name}
+                onClick={() => toggleLanguage(name)}>
+                <span>
+                  <LanguageName>{name}</LanguageName> ({count} songs)
+                </span>
+                <div
+                  className={`absolute top-[1px] right-[1px] bottom-[1px] w-20 transition-all md:w-30 ${excluded ? 'grayscale-75' : 'grayscale-0'}`}>
+                  <Flag language={[name]} className="h-full w-full rounded-r-xl object-cover" />
+                </div>
+              </NavCheckbox>
+            );
+          })}
+          {otherSongCount > 0 && (
+            <Menu.HelpText className="text-right">
+              …and <strong>{otherSongCount} songs</strong> in other languages
+            </Menu.HelpText>
+          )}
+        </>
+        <Menu.HelpText>
+          You can always update the selection in <strong>Manage Songs</strong> menu
         </Menu.HelpText>
-        {areAllLanguagesExcluded && (
-          <Menu.HelpText data-test="all-languages-excluded-warning">
+        <NextButtonContainer>
+          <NavButton
+            name="close-exclude-languages"
+            remoteIcon="confirm"
+            isDefault
+            disabled={areAllLanguagesExcluded || isLoading}
+            onClick={onClose}>
+            {closeText}
+          </NavButton>
+          <Menu.HelpText className="text-right">
+            The list will contain{' '}
             <strong>
-              <Icon icon="ic:baseline-warning" />
+              <CountUp duration={1} preserveValue end={songCount + otherSongCount} />
             </strong>{' '}
-            You excluded all the languages, pick at least one
+            songs
           </Menu.HelpText>
-        )}
-      </NextButtonContainer>
+          {areAllLanguagesExcluded && (
+            <Menu.HelpText data-test="all-languages-excluded-warning">
+              <strong>
+                <Icon icon="ic:baseline-warning" />
+              </strong>{' '}
+              You excluded all the languages, pick at least one
+            </Menu.HelpText>
+          )}
+        </NextButtonContainer>
+      </KeyboardNavContext>
     </MenuWithLogo>
   );
 }

--- a/src/routes/remote-mic/panels/remote-song-list/song-list-toolbar.tsx
+++ b/src/routes/remote-mic/panels/remote-song-list/song-list-toolbar.tsx
@@ -68,6 +68,7 @@ export default function SongListToolbar({
                 <button
                   type="button"
                   aria-label="Close search"
+                  className="flex"
                   onMouseDown={(e) => {
                     // Prevent input blur before the click fires
                     e.preventDefault();
@@ -114,9 +115,10 @@ export default function SongListToolbar({
                   size="mini"
                   onClick={open}
                   focused={excludedLanguages.length > 0 && tab === 'list'}
-                  className="scale-100 animate-none"
+                  className="aspect-square scale-100 animate-none justify-center px-0"
                   data-test="song-language-filter">
-                  🇺🇳{selectedLanguages < languages.length && <Badge>{selectedLanguages}</Badge>}
+                  <Icon icon="ic:baseline-language" size={4} />
+                  {selectedLanguages < languages.length && <Badge>{selectedLanguages}</Badge>}
                 </Button>
               )}
             </LanguageFilter>

--- a/tests/mobile-phone-mode.spec.ts
+++ b/tests/mobile-phone-mode.spec.ts
@@ -99,10 +99,10 @@ test.skip('Mobile phone mode should be playable', async ({ browser, page, browse
   });
 
   await test.step('Start singing a song', async () => {
-    await pages.mainMenuPage.navigateToSongListWithKeyboard(remoteMic1._page);
-    await remoteMic1.remoteMicMainPage.pressEnterOnRemoteMic();
-    await pages.songLanguagesPage.navigateToSongListWithKeyboard(remoteMic1._page);
-    await remoteMic1.remoteMicMainPage.pressEnterOnRemoteMic();
+    // Both the main menu and the exclude-languages screen mirror their controls to the remote mic, so
+    // tap the mirrored controls directly instead of arrow-navigating + Enter.
+    await remoteMic1.remoteMicMainPage.mirroredControl('sing-a-song').click();
+    await remoteMic1.remoteMicMainPage.mirroredControl('close-exclude-languages').click();
     await page.waitForTimeout(500); // let the list with virtualization load
     await pages.songListPage.closeTheSelectionPlaylistTip();
     await pages.songListPage.focusSong(songID);

--- a/tests/remote-mics-keyboard-mirror.spec.ts
+++ b/tests/remote-mics-keyboard-mirror.spec.ts
@@ -56,6 +56,49 @@ test('Mirrors the main menu on the remote mic and navigates directly from it', a
   });
 });
 
+test('Mirrors the exclude-languages screen on the remote mic and toggles a language directly', async ({
+  browser,
+  page,
+}) => {
+  let remoteMic: RemoteMicPages;
+
+  await test.step('Connect a remote mic with control permission', async () => {
+    remoteMic = await openAndConnectRemoteMicDirectly(page, browser, 'Player 1');
+  });
+
+  await test.step('Open the exclude-languages screen on the host', async () => {
+    await pages.smartphonesConnectionPage.goToMainMenu();
+    await pages.mainMenuPage.goToSingSong();
+  });
+
+  const remoteMicMainPage = remoteMic!.remoteMicMainPage;
+  const polishControl = remoteMicMainPage.mirroredControl('lang-Polish');
+  const closeControl = remoteMicMainPage.mirroredControl('close-exclude-languages');
+
+  await test.step('Remote mic shows the mirrored language checkboxes instead of the arrow keyboard', async () => {
+    await remoteMicMainPage.expectKeyboardModeToBe('mirror');
+    await expect(polishControl).toBeVisible();
+    await expect(closeControl).toBeVisible();
+    await expect(remoteMicMainPage.arrowUpButton).toBeHidden();
+  });
+
+  await test.step('Tapping the mirrored checkbox toggles the language on the host', async () => {
+    const hostCheckbox = pages.songLanguagesPage.getCheckbox('Polish');
+    const hostBefore = await hostCheckbox.getAttribute('data-checked');
+
+    await polishControl.click();
+
+    await expect(hostCheckbox).not.toHaveAttribute('data-checked', hostBefore ?? '');
+  });
+
+  await test.step('Tapping the mirrored close button continues to song selection on the host', async () => {
+    await pages.songLanguagesPage.ensureSongLanguageIsSelected('Polish');
+    await closeControl.click();
+
+    await expect(page.getByTestId('song-preview')).toBeVisible();
+  });
+});
+
 test('Mirrors in-game Options controls on the remote mic and toggles them directly', async ({ browser, page }) => {
   let remoteMic: RemoteMicPages;
 

--- a/tests/remote-mics-sing-a-song.spec.ts
+++ b/tests/remote-mics-sing-a-song.spec.ts
@@ -84,8 +84,9 @@ test('Remote mic should connect, be selectable and control the game', async ({ b
     // The main menu mirrors its controls to the remote mic, so tap "Sing a song" directly instead of
     // arrow-navigating + Enter.
     await remoteMic1.remoteMicMainPage.mirroredControl('sing-a-song').click();
-    await pages.songLanguagesPage.navigateToSongListWithKeyboard(remoteMic1._page);
-    await remoteMic1.remoteMicMainPage.pressEnterOnRemoteMic();
+    // The exclude-languages screen also mirrors its controls to the remote mic, so tap "Continue"
+    // directly instead of arrow-navigating + Enter.
+    await remoteMic1.remoteMicMainPage.mirroredControl('close-exclude-languages').click();
   });
 
   await test.step('Search song remotely and navigate', async () => {

--- a/tests/remote-song-list.spec.ts
+++ b/tests/remote-song-list.spec.ts
@@ -292,10 +292,9 @@ test('Selecting a song using the `select` button on the remoteMic, when selected
   });
 
   await test.step('Navigate to Song List on desktop app with remote keyboard', async () => {
-    await pages.songLanguagesPage.navigateToSongListWithKeyboard(remoteMic._page);
-    await remoteMic.remoteMicMainPage.pressEnterOnRemoteMic();
-    // The main menu mirrors its controls to the remote mic, so tap "Sing a song" directly instead of
-    // arrow-navigating + Enter.
+    // Both the main menu and the exclude-languages screen mirror their controls to the remote mic, so
+    // tap the mirrored controls directly instead of arrow-navigating + Enter.
+    await remoteMic.remoteMicMainPage.mirroredControl('close-exclude-languages').click();
     await remoteMic.remoteMicMainPage.mirroredControl('sing-a-song').click();
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added keyboard-friendly navigation to the language exclusion screen.
  - Remote controls now mirror the language selection screen, allowing languages to be toggled and the screen to be closed remotely.
  - Updated the song language filter to use a language icon and improved button layout.

- **Bug Fixes**
  - Improved consistency between desktop and remote control interactions when selecting songs and managing excluded languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->