### PR TITLE
fix(ci): serve E2E through vite preview instead of wrangler dev

### DIFF
--- a/.github/workflows/ci-improvement.yml
+++ b/.github/workflows/ci-improvement.yml
@@ -60,10 +60,12 @@ jobs:
       - uses: actions/checkout@v5
       - name: Setup Node
         uses: './.github/templates/setup-node'
-      - name: Build app
-        run: pnpm build
+      # Must run before the build: the preview server that serves the E2E suite reads the
+      # .dev.vars the build copies into build/allkaraoke_party/, not the one in the repo root.
       - name: Configure local worker secrets for E2E
         run: cp .dev.vars.example .dev.vars
+      - name: Build app
+        run: pnpm build
       - name: Run E2E tests
         uses: './.github/templates/run-playwright'
         with:
@@ -187,12 +189,14 @@ jobs:
           persist-credentials: true
       - name: Setup Node
         uses: './.github/templates/setup-node'
+      # Must run before the build: the preview server that serves the E2E suite reads the
+      # .dev.vars the build copies into build/allkaraoke_party/, not the one in the repo root.
+      - name: Configure local worker secrets for E2E
+        run: cp .dev.vars.example .dev.vars
       - name: Build app
         run: |
           git config --global --add safe.directory /__w/allkaraoke/allkaraoke
           pnpm build
-      - name: Configure local worker secrets for E2E
-        run: cp .dev.vars.example .dev.vars
       - name: Run visual regression tests and update snapshots
         uses: './.github/templates/run-playwright'
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -115,9 +115,16 @@ const config: PlaywrightTestConfig = {
   webServer: [
     prodRun
       ? {
-          // On CI we check the same build as would be deployed - with the risk that some issues won't happen locally
+          // On CI we check the same build as would be deployed - with the risk that some issues won't happen
+          // locally. CI builds in its own step, so it only needs to serve the result. Both paths serve it with
+          // `vite preview`, which runs the built Worker in the Workers runtime via @cloudflare/vite-plugin.
+          //
+          // Not `wrangler dev`: it fronts the Worker with a ProxyWorker whose fetch rejects with "Network
+          // connection lost." whenever a request is aborted mid-flight - a browser page or context closing,
+          // which the remote-mic specs do constantly. Wrangler treats that as fatal and exits, so the rest of
+          // the shard fails with ERR_CONNECTION_REFUSED.
           command: process.env.CI
-            ? 'wrangler dev --port 3010 --local'
+            ? 'vite preview --port 3010'
             : 'VITE_APP_PRERENDER=true vite build && vite preview --port 3010',
           port: 3010,
           timeout: 60_000 * 3,


### PR DESCRIPTION
## Root cause

E2E runs randomly failed with `net::ERR_CONNECTION_REFUSED at http://localhost:3010/?e2e-test` for every remaining test in a shard. Not a startup race — the web server was **exiting mid-run**. From wrangler's own debug log, captured off a reproducing CI job:

```
Error in ProxyController: Error inside ProxyWorker
  at ProxyController2.emitErrorEvent (wrangler-dist/cli.js:278673:20)
  at ProxyController2.onProxyWorkerMessage (wrangler-dist/cli.js:278550:18)
  cause: { name: 'Error', message: 'Network connection lost.' }
```

`wrangler dev` fronts the Worker with a ProxyWorker. When a request is aborted mid-flight — a browser page or context closing, which the remote-mic specs do constantly (4–5 `browser.newContext()` per test, 3 workers in parallel) — the ProxyWorker's fetch to the user Worker rejects with `Network connection lost.` and reports it to the ProxyController. `DevEnv.handleErrorEvent` has no allow-list entry for `"Error inside ProxyWorker"`, so it falls through to `this.emit("error", event)` — fatal. Wrangler exits, port 3010 stays dead, everything after it fails.

That is also why the job log only ever showed an empty `✘ [ERROR]` before the exit banner: the reason string never reached the console.

**Ruled out:** not memory (the reproducing job had 13 GB `MemAvailable`, cgroup `oom_kill 0`, and wrangler exited with status 1 rather than on a signal); not the `kj/async-io-unix.c++:186: Broken pipe` noise (passing shards log it too); and not fixable by a version bump — wrangler `4.120.0` has the identical code path and allow-list. Related upstream: [workers-sdk#4561](https://github.com/cloudflare/workers-sdk/issues/4561), [workers-sdk#4562](https://github.com/cloudflare/workers-sdk/issues/4562).

## The fix

Serve the built app with `vite preview` instead. `@cloudflare/vite-plugin` (already a dependency, already in the build) runs the same built Worker in the Workers runtime — but with no ProxyWorker in the request path, so an aborted request can no longer take the server down. It is also what the local `PROD_RUN` path already did, so CI and local now agree.

Fidelity checked by running both servers side by side against the same build — identical status and content-type on `/`, `/quick-setup`, `/song-list`, `/favicon.png`, `/unverified-songs`, `/admin/unverified-songs`, and an unknown route.

The `.dev.vars` copy moves ahead of `pnpm build` in both E2E jobs: the preview server reads the copy the build places in `build/allkaraoke_party/`, not the repo-root one.

## Verification

A/B over 10 CI jobs on the remote-mic specs, same commit and runner, only the web server differing:

| arm | outcome | `ERR_CONNECTION_REFUSED` | server exit | result |
| --- | --- | --- | --- | --- |
| vite-preview ×5 | success | 0 | 0 | 36 passed (one arm 35 + 1 skipped) |
| wrangler-dev 1 | **failure** | 14 | 1 | 5 passed, 4 failed |
| wrangler-dev 2 | **failure** | 12 | 1 | 10 passed, 3 failed |
| wrangler-dev 3 | **failure** | 12 | 1 | 20 passed, 3 failed |
| wrangler-dev 4 | success | 0 | 0 | 35 passed |
| wrangler-dev 5 | **failure** | 10 | 1 | 20 passed, 3 failed |

`wrangler dev` reproduced 4/5; `vite preview` 0/5.

Also verified locally: `CI=1 npx playwright test tests/admin-unverified-songs.spec.ts` — 8/8, so Worker secrets and KV still work through the preview server.

The diagnostics workflow and scripts used to find this have been removed; only the fix remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end and visual regression test reliability by serving the built application consistently during CI.
  * Ensured required local configuration is available before the application build runs.
  * Reduced failures caused by aborted requests during automated browser testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->