### PR TITLE
refactor(network): generalize RPC core out of remote-mic, add player-number model

### DIFF
--- a/src/modules/network/rpc/define.ts
+++ b/src/modules/network/rpc/define.ts
@@ -1,0 +1,25 @@
+import { MutationDefinition, QueryDefinition, RpcContext } from './types';
+
+/** Declares a read-only server handler. Defaults to 'read' permission. */
+export function defineQuery<TArgs extends any[], TReturn>(
+  handler: (context: RpcContext, ...args: TArgs) => TReturn | Promise<TReturn>,
+  options?: { permission?: 'read' | 'write' },
+): QueryDefinition<TArgs, TReturn> {
+  return {
+    type: 'query',
+    permission: options?.permission ?? 'read',
+    handler,
+  };
+}
+
+/** Declares a side-effecting server handler. Defaults to 'write' permission. */
+export function defineMutation<TArgs extends any[], TReturn = void>(
+  handler: (context: RpcContext, ...args: TArgs) => TReturn | Promise<TReturn>,
+  options?: { permission?: 'read' | 'write' },
+): MutationDefinition<TArgs, TReturn> {
+  return {
+    type: 'mutation',
+    permission: options?.permission ?? 'write',
+    handler,
+  };
+}

--- a/src/modules/network/rpc/ping-pong-tracker.ts
+++ b/src/modules/network/rpc/ping-pong-tracker.ts
@@ -1,0 +1,65 @@
+export interface PingPongTrackerOptions {
+  /** Delay between a pong arriving and the next ping going out. */
+  intervalMs?: number;
+  /** Latency reported before the first round trip completes. */
+  initialLatency?: number;
+  /** Called with every fresh measurement — remote mic reports pings to analytics through it. */
+  onMeasurement?: (latencyMs: number) => void;
+}
+
+/** Round-trip latency loop shared by the remote-mic and online clients: send a ping, measure the
+ * pong, re-arm after `intervalMs`. The caller owns the transport — it hands in a send function and
+ * feeds back the pongs it receives, so the tracker stays transport- and protocol-agnostic. */
+export class PingPongTracker {
+  private readonly intervalMs: number;
+  private latencyMs: number;
+  private pingStartedAt = 0;
+  private timeout: ReturnType<typeof setTimeout> | null = null;
+  private send: (() => void) | null = null;
+
+  public constructor(private readonly options: PingPongTrackerOptions = {}) {
+    this.intervalMs = options.intervalMs ?? 2_000;
+    this.latencyMs = options.initialLatency ?? 0;
+  }
+
+  /** Starts (or restarts) the loop: pings right away, then again after every pong. */
+  public start = (send: () => void): void => {
+    if (this.timeout) clearTimeout(this.timeout);
+    this.timeout = null;
+    this.send = send;
+    this.ping();
+  };
+
+  private ping = () => {
+    this.timeout = null;
+    this.pingStartedAt = Date.now();
+    this.send?.();
+  };
+
+  /** Feed in an incoming pong: records the round trip and schedules the next ping. Pongs arriving
+   * without a ping in flight are ignored, so the loop can never fork into two. */
+  public handlePong = (): void => {
+    if (!this.pingStartedAt) return;
+    this.latencyMs = Date.now() - this.pingStartedAt;
+    this.pingStartedAt = 0;
+    this.options.onMeasurement?.(this.latencyMs);
+    this.timeout = setTimeout(this.ping, this.intervalMs);
+  };
+
+  /** Latest measured round-trip latency, ms. */
+  public getLatency = (): number => this.latencyMs;
+
+  /** True between a ping going out and its pong coming back. */
+  public isPinging = (): boolean => this.pingStartedAt !== 0;
+
+  /** When the outstanding ping was sent (0 when none is in flight) — lets a readout keep counting
+   * up while a pong is overdue instead of showing the last, stale measurement. */
+  public getPingStartedAt = (): number => this.pingStartedAt;
+
+  /** Stops the loop and drops the outstanding ping. */
+  public stop = (): void => {
+    if (this.timeout) clearTimeout(this.timeout);
+    this.timeout = null;
+    this.pingStartedAt = 0;
+  };
+}

--- a/src/modules/network/rpc/rpc-client.ts
+++ b/src/modules/network/rpc/rpc-client.ts
@@ -1,0 +1,130 @@
+import { v4 as uuid } from 'uuid';
+
+import { ExtractContract, HandlerMap, RpcRequest, RpcResponse } from './types';
+
+/** The only thing the RPC core needs to know about an inbound frame. Both feature protocols
+ * discriminate their messages on `t`, so the core can pick out its own `rpc-res` replies without
+ * knowing either union — which is the whole point of it not importing one. */
+export interface RpcIncomingMessage {
+  t: string;
+}
+
+/** Minimal transport shape the RPC proxy needs. remote-mic's ClientTransport and the online
+ * room transport both satisfy it structurally, each with their own message unions: their
+ * listeners take a wider type than `RpcIncomingMessage` and their `sendEvent` accepts more
+ * than an `RpcRequest`, both of which are fine in that direction. */
+export interface RpcClientTransport {
+  isConnected(): boolean;
+  addListener(listener: (message: RpcIncomingMessage) => void): unknown;
+  removeListener(listener: (message: RpcIncomingMessage) => void): void;
+  sendEvent(message: RpcRequest): void;
+}
+
+/** Fire-and-forget mirror of a client contract: same arguments, no result, rejections swallowed. */
+export type FireAndForgetContract<T> = {
+  [NS in keyof T]: {
+    [M in keyof T[NS]]: T[NS][M] extends (...args: infer A) => unknown ? (...args: A) => void : never;
+  };
+};
+
+type AsyncNamespaces = Record<string, Record<string, (...args: never[]) => Promise<unknown>>>;
+
+/**
+ * Wraps an RPC proxy so every call is fire-and-forget: nothing to await, and a rejection
+ * (disconnect, timeout, server error) is swallowed instead of surfacing as an unhandled rejection.
+ * Use it for calls whose result nobody reads; keep the plain `rpc` proxy when the answer matters.
+ */
+export function createFireAndForgetProxy<T extends object>(rpc: T): FireAndForgetContract<T> {
+  return new Proxy({} as FireAndForgetContract<T>, {
+    get(_target, ns: string) {
+      const namespace = (rpc as AsyncNamespaces)[ns];
+      return new Proxy(
+        {},
+        {
+          get(_nsTarget, method: string) {
+            return (...args: never[]) => {
+              void namespace[method](...args).catch(() => undefined);
+            };
+          },
+        },
+      );
+    },
+  });
+}
+
+/**
+ * Creates a namespaced proxy that mirrors the server handler contract.
+ * Property access returns a sub-proxy for a namespace; method calls serialize to
+ * RpcRequest messages and return a Promise resolved with the server response (10 s timeout).
+ *
+ * @param getTransport - Returns the active transport (or undefined when disconnected).
+ * @param onDisconnect - Registers a one-shot callback that fires when the connection drops.
+ *   Must return an unsubscribe function so in-flight requests can clean up before the
+ *   callback fires (e.g. when they already resolved via rpc-res).
+ */
+export function createRpcProxy<T extends HandlerMap>(
+  getTransport: () => RpcClientTransport | undefined,
+  onDisconnect: (callback: () => void) => () => void,
+): ExtractContract<T> {
+  return new Proxy({} as ExtractContract<T>, {
+    get(_target, ns: string) {
+      return new Proxy(
+        {},
+        {
+          get(_nsTarget, method: string) {
+            return (...args: unknown[]): Promise<unknown> => {
+              const transport = getTransport();
+              if (!transport?.isConnected()) {
+                return Promise.reject(new Error(`Not connected (calling ${ns}.${method})`));
+              }
+
+              const id = uuid();
+
+              return new Promise<unknown>((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                  cleanup();
+                  reject(new Error(`RPC timeout: ${ns}.${method}`));
+                }, 10_000);
+
+                const removeDisconnectListener = onDisconnect(() => {
+                  cleanup();
+                  reject(new Error(`Transport disconnected during RPC: ${ns}.${method}`));
+                });
+
+                const listener = (event: RpcIncomingMessage) => {
+                  if (event.t !== 'rpc-res') return;
+
+                  const response = event as RpcResponse;
+                  if (response.id !== id) return;
+
+                  cleanup();
+                  if (response.error) {
+                    reject(new Error(response.error));
+                  } else {
+                    resolve(response.result);
+                  }
+                };
+
+                const cleanup = () => {
+                  clearTimeout(timeout);
+                  transport.removeListener(listener);
+                  removeDisconnectListener();
+                };
+
+                transport.addListener(listener);
+
+                const request: RpcRequest = { t: 'rpc', ns, method, args, id };
+                try {
+                  transport.sendEvent(request);
+                } catch (err) {
+                  cleanup();
+                  reject(err instanceof Error ? err : new Error(String(err)));
+                }
+              });
+            };
+          },
+        },
+      );
+    },
+  });
+}

--- a/src/modules/network/rpc/rpc-server.ts
+++ b/src/modules/network/rpc/rpc-server.ts
@@ -1,0 +1,96 @@
+import {
+  AnyDefinition,
+  AnySubscriptionChannels,
+  HandlerMap,
+  RpcCall,
+  RpcContext,
+  RpcPublish,
+  RpcRequest,
+  RpcResponse,
+} from './types';
+
+/** Minimal shape of a connected peer the RPC server can respond to. Both remote-mic's
+ * SenderInterface and the online room's connection wrapper satisfy it structurally — they
+ * accept wider payload types than the two frames the RPC server ever sends. */
+export interface RpcSenderInterface {
+  peer: string;
+  send(payload: RpcResponse | RpcCall): void;
+}
+
+/** Handles incoming RPC requests from clients: permission checks, dispatch, and response sending.
+ * Feature-agnostic: the hosting server supplies permission lookup, subscription broadcast and
+ * peer removal, and its own transport/message types. */
+export class RpcServer<T extends HandlerMap, TChannels extends AnySubscriptionChannels = AnySubscriptionChannels> {
+  constructor(
+    private readonly handlers: T,
+    private readonly getPermission: (peerId: string) => 'read' | 'write',
+    private readonly broadcastToSubscribers: (channel: keyof TChannels, message: RpcPublish<TChannels>) => void,
+    private readonly removePlayerFromTransport: (peerId: string) => void,
+  ) {}
+
+  /** Validates, permission-checks, and dispatches an incoming RPC request, then sends the response. */
+  public handleMessage = async (message: RpcRequest, sender: RpcSenderInterface): Promise<void> => {
+    const namespace = this.handlers[message.ns];
+    if (!namespace) {
+      sender.send({ t: 'rpc-res', id: message.id, error: `Unknown namespace: ${message.ns}` });
+      return;
+    }
+
+    const definition: AnyDefinition | undefined = namespace[message.method];
+    if (!definition) {
+      sender.send({
+        t: 'rpc-res',
+        id: message.id,
+        error: `Unknown method: ${message.ns}.${message.method}`,
+      });
+      return;
+    }
+
+    const callerPermission = this.getPermission(sender.peer);
+    // 'write' permission requirement blocks 'read' callers; 'read' allows everyone
+    if (definition.permission === 'write' && callerPermission !== 'write') {
+      sender.send({ t: 'rpc-res', id: message.id, error: 'Permission denied' });
+      return;
+    }
+
+    const context: RpcContext = {
+      senderId: sender.peer,
+      permission: callerPermission,
+      removePlayer: (peerId) => this.removePlayerFromTransport(peerId),
+    };
+
+    try {
+      const result = await definition.handler(context, ...message.args);
+      sender.send({ t: 'rpc-res', id: message.id, result });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      sender.send({ t: 'rpc-res', id: message.id, error: errorMessage });
+    }
+  };
+
+  /** Push data to all clients subscribed to a channel. */
+  public publish = <C extends keyof TChannels>(channel: C, data: TChannels[C]): void => {
+    this.broadcastToSubscribers(channel, { t: 'rpc-pub', channel, data });
+  };
+
+  /** Send a server-initiated call to a specific client. */
+  public callClient = (sender: RpcSenderInterface, method: string, ...args: unknown[]): void => {
+    sender.send({ t: 'rpc-call', method, args });
+  };
+
+  /** Send a server-initiated call to every currently connected client. */
+  public broadcastClientCall = (
+    connections: ReadonlyArray<{ connection: RpcSenderInterface }>,
+    method: string,
+    ...args: unknown[]
+  ): void => {
+    connections.forEach(({ connection }) => {
+      connection.send({ t: 'rpc-call', method, args });
+    });
+  };
+
+  /** Forcibly disconnect a peer from the transport. */
+  public removePlayer = (peerId: string): void => {
+    this.removePlayerFromTransport(peerId);
+  };
+}

--- a/src/modules/network/rpc/server-subscription-registry.ts
+++ b/src/modules/network/rpc/server-subscription-registry.ts
@@ -1,0 +1,68 @@
+import { AnySubscriptionChannels, RpcPublish } from './types';
+
+export interface ServerSubscriptionRegistryOptions<TChannels extends AnySubscriptionChannels> {
+  /** Values computed on demand for channels that have not been published to yet, so a peer
+   * subscribing before the first publish still receives the current state. */
+  fallbacks?: { [C in keyof TChannels]?: () => TChannels[C] };
+}
+
+/** Server-side half of the pub/sub channels: who subscribes to what, the last value published on
+ * each channel, and the fan-out. Generic over the channel map so each feature (remote-mic, online)
+ * can run its own instance with its own channels. */
+export class ServerSubscriptionRegistry<TChannels extends AnySubscriptionChannels> {
+  private subscribers = new Map<keyof TChannels, Set<string>>();
+  // Stores the most-recently published value per channel so newly subscribing peers can receive
+  // the current state immediately without waiting for the next change.
+  private lastValues = new Map<keyof TChannels, unknown>();
+
+  public constructor(private readonly options: ServerSubscriptionRegistryOptions<TChannels> = {}) {}
+
+  public subscribe = (peerId: string, channel: keyof TChannels): void => {
+    const subscribers = this.subscribers.get(channel);
+    if (subscribers) {
+      subscribers.add(peerId);
+    } else {
+      this.subscribers.set(channel, new Set([peerId]));
+    }
+  };
+
+  public unsubscribe = (peerId: string, channel: keyof TChannels): void => {
+    this.subscribers.get(channel)?.delete(peerId);
+  };
+
+  /** Drops a peer from every channel — call when its connection closes. */
+  public removePeer = (peerId: string): void => {
+    this.subscribers.forEach((subscribers) => subscribers.delete(peerId));
+  };
+
+  /** Caches `data` as the channel's latest value and hands the ready-made rpc-pub message to
+   * `send` once per subscribed peer. */
+  public publish = <C extends keyof TChannels>(
+    channel: C,
+    data: TChannels[C],
+    send: (peerId: string, message: RpcPublish<TChannels>) => void,
+  ): void => {
+    this.setLastValue(channel, data);
+    const subscribers = this.subscribers.get(channel);
+    if (!subscribers?.size) return;
+    const message = { t: 'rpc-pub', channel, data } as RpcPublish<TChannels>;
+    subscribers.forEach((peerId) => send(peerId, message));
+  };
+
+  /** Records a published value without fanning it out — for hosts that keep their subscriber list
+   * elsewhere and broadcast themselves (remote mic keeps its in `RemoteMicManager`). */
+  public setLastValue = <C extends keyof TChannels>(channel: C, data: TChannels[C]): void => {
+    this.lastValues.set(channel, data);
+  };
+
+  /** What a freshly subscribed peer should be replayed: the last published value, or the channel's
+   * fallback when nothing has been published yet. `undefined` when there is nothing to replay — the
+   * value comes wrapped so that a channel explicitly published as `undefined` still replays. */
+  public getLastValue = <C extends keyof TChannels>(channel: C): { data: TChannels[C] } | undefined => {
+    if (this.lastValues.has(channel)) {
+      return { data: this.lastValues.get(channel) as TChannels[C] };
+    }
+    const fallback = this.options.fallbacks?.[channel];
+    return fallback ? { data: fallback() } : undefined;
+  };
+}

--- a/src/modules/network/rpc/subscription-manager.ts
+++ b/src/modules/network/rpc/subscription-manager.ts
@@ -1,0 +1,79 @@
+import { AnySubscriptionChannels } from './types';
+
+type ChannelCallback<TChannels extends AnySubscriptionChannels, C extends keyof TChannels> = (
+  data: TChannels[C],
+) => void;
+
+/** Manages pub/sub channel subscriptions on the client side. Tracks ref-counts, caches the latest
+ * data per channel, and re-subscribes automatically after reconnect via `setSendFunctions`.
+ * Generic over the channel map so each feature (remote-mic, online) can run its own instance. */
+export class ClientSubscriptionManager<TChannels extends AnySubscriptionChannels> {
+  private subscriberCounts: Partial<Record<keyof TChannels, number>> = {};
+  private latestData: Partial<TChannels> = {};
+  private callbacks = new Map<keyof TChannels, Set<ChannelCallback<TChannels, any>>>();
+
+  private sendSubscribeFn: ((channel: keyof TChannels) => void) | null = null;
+  private sendUnsubscribeFn: ((channel: keyof TChannels) => void) | null = null;
+
+  /** Called by the network client after each successful connection to wire up the transport send functions.
+   * Re-sends subscriptions for all currently active channels so the server is notified on reconnect. */
+  public setSendFunctions = (
+    sendSubscribe: (channel: keyof TChannels) => void,
+    sendUnsubscribe: (channel: keyof TChannels) => void,
+  ): void => {
+    this.sendSubscribeFn = sendSubscribe;
+    this.sendUnsubscribeFn = sendUnsubscribe;
+
+    for (const [channel, count] of Object.entries(this.subscriberCounts) as [keyof TChannels, number][]) {
+      if (count > 0) {
+        sendSubscribe(channel);
+      }
+    }
+  };
+
+  /** Returns the latest cached data for a channel, or undefined before the first push. Stable
+   * reference between publishes, so it can back `useSyncExternalStore`'s `getSnapshot`. */
+  public getSnapshot = <C extends keyof TChannels>(channel: C): TChannels[C] | undefined => {
+    return this.latestData[channel];
+  };
+
+  /** Subscribe to a channel. Delivers cached data immediately if available. Returns an unsubscribe function. */
+  public subscribe = <C extends keyof TChannels>(channel: C, callback: ChannelCallback<TChannels, C>): (() => void) => {
+    const count = this.subscriberCounts[channel] ?? 0;
+    if (count === 0) {
+      this.sendSubscribeFn?.(channel);
+    }
+    this.subscriberCounts[channel] = count + 1;
+
+    if (!this.callbacks.has(channel)) {
+      this.callbacks.set(channel, new Set());
+    }
+    this.callbacks.get(channel)!.add(callback as ChannelCallback<TChannels, any>);
+
+    if (channel in this.latestData) {
+      callback(this.latestData[channel] as TChannels[C]);
+    }
+
+    return () => this.unsubscribeInternal(channel, callback);
+  };
+
+  private unsubscribeInternal = <C extends keyof TChannels>(
+    channel: C,
+    callback: ChannelCallback<TChannels, C>,
+  ): void => {
+    this.callbacks.get(channel)?.delete(callback as ChannelCallback<TChannels, any>);
+    const count = this.subscriberCounts[channel] ?? 0;
+    if (count <= 1) {
+      this.subscriberCounts[channel] = 0;
+      this.sendUnsubscribeFn?.(channel);
+    } else {
+      this.subscriberCounts[channel] = count - 1;
+    }
+  };
+
+  /** Called by the network client when an rpc-pub message arrives; caches data and notifies subscribers. */
+  public handlePublish = <C extends keyof TChannels>(channel: C, data: TChannels[C]): void => {
+    this.latestData[channel] = data;
+    this.callbacks.get(channel)?.forEach((callback) => callback(data));
+  };
+}

--- a/src/modules/network/rpc/types.ts
+++ b/src/modules/network/rpc/types.ts
@@ -1,0 +1,94 @@
+/** Context passed to every server-side handler, scoped to the calling peer. */
+export interface RpcContext {
+  senderId: string;
+  permission: 'read' | 'write';
+  /** Forcibly removes a peer from the transport. */
+  removePlayer: (peerId: string) => void;
+}
+
+/** A read-only server handler that returns data without side effects. */
+export interface QueryDefinition<TArgs extends any[], TReturn> {
+  type: 'query';
+  permission: 'read' | 'write';
+  handler: (context: RpcContext, ...args: TArgs) => TReturn | Promise<TReturn>;
+}
+
+/** A server handler that performs a side-effecting operation. */
+export interface MutationDefinition<TArgs extends any[], TReturn = void> {
+  type: 'mutation';
+  permission: 'read' | 'write';
+  handler: (context: RpcContext, ...args: TArgs) => TReturn | Promise<TReturn>;
+}
+
+export type AnyDefinition = QueryDefinition<any[], any> | MutationDefinition<any[], any>;
+
+export type HandlerMap = Record<string, Record<string, AnyDefinition>>;
+
+/** Strips the RpcContext first parameter and wraps the return in Promise, deriving the client-facing call signature. */
+type StripContext<H> = H extends (context: RpcContext, ...args: infer A) => infer R
+  ? (...args: A) => Promise<Awaited<R>>
+  : never;
+
+/** Derives the typed client proxy contract from a server HandlerMap. */
+export type ExtractContract<T extends HandlerMap> = {
+  [NS in keyof T]: {
+    [M in keyof T[NS]]: StripContext<T[NS][M]['handler']>;
+  };
+};
+
+/** Map of channel name → data type pushed on that channel. Each feature (remote-mic, online)
+ * supplies its own map so the RPC core stays feature-agnostic. */
+export type AnySubscriptionChannels = Record<string, unknown>;
+
+// --- Wire message types ---
+
+/** Client → Server: invoke a server handler. */
+export interface RpcRequest {
+  t: 'rpc';
+  ns: string;
+  method: string;
+  args: any[];
+  id: string;
+}
+
+/** Server → Client: response to an RpcRequest. */
+export interface RpcResponse {
+  t: 'rpc-res';
+  id: string;
+  result?: any;
+  error?: string;
+}
+
+/** Server → Client: server-initiated call to a client handler. */
+export interface RpcCall {
+  t: 'rpc-call';
+  method: string;
+  args: any[];
+}
+
+/** Client → Server: subscribe to a named push channel. */
+export interface RpcSubscribe<TChannels extends AnySubscriptionChannels = AnySubscriptionChannels> {
+  t: 'rpc-sub';
+  channel: keyof TChannels;
+}
+
+/** Server → Client: push updated data to all subscribers of a channel. */
+export interface RpcPublish<TChannels extends AnySubscriptionChannels = AnySubscriptionChannels> {
+  t: 'rpc-pub';
+  channel: keyof TChannels;
+  data: TChannels[keyof TChannels];
+}
+
+/** Client → Server: unsubscribe from a named push channel. */
+export interface RpcUnsubscribe<TChannels extends AnySubscriptionChannels = AnySubscriptionChannels> {
+  t: 'rpc-unsub';
+  channel: keyof TChannels;
+}
+
+export type RpcMessages<TChannels extends AnySubscriptionChannels = AnySubscriptionChannels> =
+  | RpcRequest
+  | RpcResponse
+  | RpcCall
+  | RpcSubscribe<TChannels>
+  | RpcPublish<TChannels>
+  | RpcUnsubscribe<TChannels>;

--- a/src/modules/network/rpc/use-subscription-factory.ts
+++ b/src/modules/network/rpc/use-subscription-factory.ts
@@ -1,0 +1,22 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { ClientSubscriptionManager } from './subscription-manager';
+import { AnySubscriptionChannels } from './types';
+
+/** Builds the React hook that reads a channel off a specific manager instance. Reading the cache
+ * through `useSyncExternalStore` means a mounting subscriber renders the latest value right away,
+ * instead of rendering empty and catching up one state update later. Each feature (remote-mic,
+ * online) creates the hook once for its own manager.
+ *
+ * Lives apart from the manager itself so the transport core stays React-free — the server side of
+ * it is bundled into the PartyKit worker. */
+export const createSubscriptionHook = <TChannels extends AnySubscriptionChannels>(
+  manager: ClientSubscriptionManager<TChannels>,
+) =>
+  /** Subscribes to a push channel and returns the latest data, or undefined before the first push. */
+  function useSubscription<C extends keyof TChannels>(channel: C): TChannels[C] | undefined {
+    const subscribe = useCallback((onStoreChange: () => void) => manager.subscribe(channel, onStoreChange), [channel]);
+    const getSnapshot = useCallback(() => manager.getSnapshot(channel), [channel]);
+
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  };

--- a/src/modules/players/player-number.ts
+++ b/src/modules/players/player-number.ts
@@ -1,0 +1,19 @@
+/** Central player-number type and limits. The game engine (drawing, scoring, events) supports
+ * up to MAX_SUPPORTED_PLAYERS; local party mode stays capped at MAX_PLAYERS while online mode
+ * uses ONLINE_MAX_PLAYERS. */
+export type PlayerNumber = 0 | 1 | 2 | 3 | 4 | 5;
+
+/** Highest number of players the shared game primitives (colors, results, events) can render. */
+export const MAX_SUPPORTED_PLAYERS = 6;
+
+/** Local party mode player cap — unchanged from before online mode was added. */
+export const MAX_PLAYERS = 4;
+
+/** Online mode player cap. */
+export const ONLINE_MAX_PLAYERS = 6;
+
+export const PLAYER_NUMBERS: PlayerNumber[] = [0, 1, 2, 3, 4, 5];
+
+/** The seats local party mode offers. Raising MAX_PLAYERS should widen every local screen at once,
+ * so iterate this instead of inlining a tuple. */
+export const LOCAL_PLAYER_NUMBERS: PlayerNumber[] = PLAYER_NUMBERS.slice(0, MAX_PLAYERS);


### PR DESCRIPTION
## Summary
- Moves the generic RPC transport core (request/response, pub/sub, ping-pong tracking, subscription registry) out of `modules/remote-mic/network/rpc` into a standalone `modules/network/rpc`, so it can be shared between remote-mic and the new online-room server without remote-mic-specific coupling.
- Adds `modules/players/player-number.ts`: the central `PlayerNumber` type/consts (`MAX_SUPPORTED_PLAYERS`, `MAX_PLAYERS`, `ONLINE_MAX_PLAYERS`, `LOCAL_PLAYER_NUMBERS`), laying the groundwork for online's 6-seat rooms vs local party mode's 4.
- Purely additive at this point — nothing in the app consumes the new generic module or type yet (that lands in PR 4), so this PR is safe to land standalone.

Stack: **2 of 8**. Depends on #613.