### PR TITLE
feat(online): add setup wizard and lobby screens

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -46,7 +46,19 @@
     "src/modules/online/client/hooks.ts",
     "src/modules/online/client/song-preview.ts",
     "src/modules/online/client/song-transfer.ts",
-    "src/modules/online/format-score.ts"
+    "src/modules/online/format-score.ts",
+    "src/routes/online/components/kick-player.tsx",
+    "src/routes/online/components/participant-badges.tsx",
+    "src/routes/online/components/participant-slot.tsx",
+    "src/routes/online/hooks/use-online-name.ts",
+    "src/routes/online/hooks/use-song-upload.ts",
+    "src/routes/online/lobby/customize-modal.tsx",
+    "src/routes/online/lobby/lobby-song-card.tsx",
+    "src/routes/online/lobby/lobby.tsx",
+    "src/routes/online/lobby/participant-list.tsx",
+    "src/routes/online/lobby/room-code-panel.tsx",
+    "src/routes/online/lobby/song-players-panel.tsx",
+    "src/routes/online/setup-wizard.tsx"
   ],
   "ignoreDependencies": [
     "vite-tsconfig-paths",

--- a/src/routes/online/components/kick-player.tsx
+++ b/src/routes/online/components/kick-player.tsx
@@ -1,0 +1,40 @@
+import ConfirmModal from '~/modules/elements/akui/confirm-modal';
+import { Icon } from '~/modules/elements/akui/icon';
+import { trackOnlinePlayerKicked } from '~/modules/online/client/online-analytics';
+import OnlineClient from '~/modules/online/client/online-client';
+import { OnlineParticipant } from '~/modules/online/protocol/types';
+
+interface Props {
+  participant: OnlineParticipant;
+}
+
+/**
+ * The host's "remove a singer" control, identical wherever it's offered (lobby, pause menu): the
+ * button, the confirmation it opens and the kick itself. Drop it on a singer's row — whether the
+ * confirmation is up is the modal's business, and it pauses the surrounding screen's keyboard
+ * navigation on its own.
+ */
+export default function KickPlayer({ participant }: Props) {
+  const kick = () => {
+    OnlineClient.send.room.kickPlayer(participant.id);
+    trackOnlinePlayerKicked();
+  };
+
+  return (
+    <ConfirmModal
+      title={`Remove ${participant.name}?`}
+      description="They will be removed from the room and won't be able to rejoin."
+      onConfirm={kick}
+      dataTestPrefix="online-kick-confirm"
+      cancelButton={<ConfirmModal.CancelButton name="cancel-kick-participant">Cancel</ConfirmModal.CancelButton>}
+      confirmButton={<ConfirmModal.ConfirmButton name="confirm-kick-participant">Remove</ConfirmModal.ConfirmButton>}>
+      <button
+        type="button"
+        title={`Remove ${participant.name} from the room`}
+        className="flex cursor-pointer items-center opacity-75 hover:text-red-400 hover:opacity-100"
+        data-test={`online-kick-${participant.playerNumber}`}>
+        <Icon icon="ic:baseline-close" className="h-5 w-5" />
+      </button>
+    </ConfirmModal>
+  );
+}

--- a/src/routes/online/components/participant-badges.tsx
+++ b/src/routes/online/components/participant-badges.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react';
+
+import { Icon } from '~/modules/elements/akui/icon';
+import { PlayerStats, SongVote } from '~/modules/online/protocol/types';
+import { cn } from '~/utils/cn';
+
+interface Props {
+  stats?: PlayerStats;
+  /** The singer's thumbs up/down on the song currently on screen, if any. */
+  vote?: SongVote | null;
+  /** Extra tags and actions, appended after the ping and the vote. */
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * The trailing cluster of a singer row — ping, vote, and whatever tags the screen adds. Positioned
+ * rather than in flow, so it never pushes the row's centered name off center, and above the volume
+ * bar filling in behind it.
+ */
+function ParticipantBadges({ stats, vote, children, className }: Props) {
+  return (
+    <span className={cn('absolute inset-y-0 right-2 z-1 flex items-center gap-1.5', className)}>
+      {stats && (
+        <span className="text-xs [font-variant-numeric:tabular-nums] opacity-60" data-test="participant-ping">
+          {stats.ping} ms
+        </span>
+      )}
+      {vote && (
+        <Icon
+          icon={vote === 'up' ? 'ic:baseline-thumb-up' : 'ic:baseline-thumb-down'}
+          size={4}
+          title={`Voted ${vote === 'up' ? 'for' : 'against'} this song`}
+        />
+      )}
+      {children}
+    </span>
+  );
+}
+
+export default ParticipantBadges;

--- a/src/routes/online/components/participant-slot.tsx
+++ b/src/routes/online/components/participant-slot.tsx
@@ -1,0 +1,133 @@
+import { ReactNode } from 'react';
+
+import { Icon } from '~/modules/elements/akui/icon';
+import { Tag } from '~/modules/elements/akui/tag';
+import { PlayerColorDot } from '~/modules/elements/player-color-dot';
+import { useOnlinePlayersStats, useOnlineSongPreview, useOnlineSongVotes } from '~/modules/online/client/hooks';
+import { OnlineParticipant, SongVote } from '~/modules/online/protocol/types';
+import KickPlayer from '~/routes/online/components/kick-player';
+import ParticipantBadges from '~/routes/online/components/participant-badges';
+import { MicCheckSlotShell } from '~/routes/sing-a-song/song-selection/components/song-settings/mic-check/mic-check-slot';
+
+/**
+ * A singer's thumbs up/down, but only while it still applies to the song on screen: votes are
+ * remembered per song, so the one left over from a previously browsed song must not leak into a row.
+ */
+function useParticipantVote(participantId: string): SongVote | null {
+  const votes = useOnlineSongVotes();
+  const preview = useOnlineSongPreview();
+  const vote = votes[participantId];
+
+  return vote && vote.songId === preview?.songId ? vote.vote : null;
+}
+
+interface Props {
+  participant: OnlineParticipant;
+  /** This browser's participant id — its own row reads the mic locally instead of over the wire. */
+  selfId: string;
+  /** Who the room's host is: drives the `host` tag and gates the kick button. */
+  hostId?: string | null;
+  size?: 'regular' | 'compact';
+  /** The singer's reported ping. */
+  showPing?: boolean;
+  /** Their thumbs up/down on the song currently being browsed. */
+  showVote?: boolean;
+  /** The `you` / `host` / `disconnected` pills. */
+  showTags?: boolean;
+  /** Leading dot in the singer's player color, for rows too tight for the volume bar to read as
+   * theirs at a glance. */
+  showColorDot?: boolean;
+  /** Offer the host the kick (and ban) control on other singers' rows. */
+  canKick?: boolean;
+  /** Opens the name/color editor. Rendered on the own row only. */
+  onEdit?: () => void;
+  /** Screen-specific extras, appended after the tags (a score, a ready tick, …). */
+  children?: ReactNode;
+  className?: string;
+  'data-test'?: string;
+}
+
+/**
+ * One singer, rendered as the same mic-check row the local game uses: a player-colored volume bar
+ * filling in behind the name, plus the trailing badge cluster each screen wants some subset of. The
+ * lobby, the song browser's player panel, the pause menu and the readiness overlay all come through
+ * here, so the wiring around `MicCheckSlotShell` — stats lookup, vote resolution, local-vs-remote
+ * volume, the host actions — exists once instead of four times.
+ */
+function ParticipantSlot({
+  participant,
+  selfId,
+  hostId = null,
+  size,
+  showPing = true,
+  showVote = false,
+  showTags = false,
+  showColorDot = false,
+  canKick = false,
+  onEdit,
+  children,
+  className,
+  'data-test': dataTest,
+}: Props) {
+  const stats = useOnlinePlayersStats();
+  const vote = useParticipantVote(participant.id);
+
+  const isSelf = participant.id === selfId;
+  const canEdit = onEdit !== undefined && isSelf;
+  const showKick = canKick && hostId === selfId && !isSelf;
+  const hasBadges = showPing || showVote || showTags || canEdit || showKick || children !== undefined;
+
+  return (
+    <MicCheckSlotShell
+      data-test={dataTest}
+      data-connected={participant.connected}
+      data-vote={showVote ? (vote ?? 'none') : undefined}
+      className={className}
+      size={size}
+      playerNumber={participant.playerNumber}
+      // Stays centered in the row (the badges are positioned, not in flow); the width cap keeps a
+      // long name from running underneath them, so it's only wanted when there are any
+      name={
+        <span className={`flex items-center gap-2 ${hasBadges ? 'max-w-[calc(100%-16rem)]' : ''}`}>
+          {showColorDot && <PlayerColorDot number={participant.playerNumber} />}
+          <span className={`truncate ${participant.connected ? '' : 'line-through opacity-50'}`}>
+            {participant.name}
+          </span>
+        </span>
+      }
+      connected={participant.connected}
+      // The own volume comes straight from the local mic pipeline (no re-render per frame);
+      // everyone else's is the level they report to the room.
+      volume={isSelf ? { type: 'local' } : { type: 'remote', volume: stats[participant.id]?.volume ?? 0 }}>
+      {hasBadges && (
+        <ParticipantBadges stats={showPing ? stats[participant.id] : undefined} vote={showVote ? vote : null}>
+          {showTags && (
+            <>
+              {isSelf && (
+                <Tag className="bg-black text-white" data-test="participant-self">
+                  you
+                </Tag>
+              )}
+              {participant.id === hostId && <Tag data-test="participant-host">host</Tag>}
+              {!participant.connected && <Tag>disconnected</Tag>}
+            </>
+          )}
+          {children}
+          {canEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              title="Change your name or color"
+              className="hover:text-active flex cursor-pointer items-center opacity-75 hover:opacity-100"
+              data-test="customize-button">
+              <Icon icon="ic:baseline-edit" size={5} />
+            </button>
+          )}
+          {showKick && <KickPlayer participant={participant} />}
+        </ParticipantBadges>
+      )}
+    </MicCheckSlotShell>
+  );
+}
+
+export default ParticipantSlot;

--- a/src/routes/online/hooks/use-online-name.ts
+++ b/src/routes/online/hooks/use-online-name.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+
+import { MAX_NAME_LENGTH } from '~/consts';
+import { ONLINE_NAME_KEY } from '~/modules/online/client/online-client';
+import storage from '~/modules/utils/storage';
+
+/** Local storage (not session) so the name survives closing the tab — one less step on every visit. */
+export const getStoredOnlineName = () =>
+  (storage.local.getItem<string>(ONLINE_NAME_KEY) ?? '').trim().slice(0, MAX_NAME_LENGTH);
+
+export const setStoredOnlineName = (name: string) =>
+  storage.local.setItem(ONLINE_NAME_KEY, name.trim().slice(0, MAX_NAME_LENGTH));
+
+/**
+ * The remembered display name for online rooms. `hasStoredName` lets the setup wizard skip the name
+ * step entirely for a returning singer — same behaviour as the remote mic's `useRemoteMicName`.
+ */
+export default function useOnlineName() {
+  const [name, setName] = useState(getStoredOnlineName);
+
+  const persistName = useCallback((next: string) => {
+    const trimmed = next.trim().slice(0, MAX_NAME_LENGTH);
+    setStoredOnlineName(trimmed);
+    setName(trimmed);
+  }, []);
+
+  return { name, hasStoredName: name !== '', setName: persistName };
+}

--- a/src/routes/online/hooks/use-song-upload.ts
+++ b/src/routes/online/hooks/use-song-upload.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+import { SongPreview } from '~/interfaces';
+import { trackOnlineSongSelected } from '~/modules/online/client/online-analytics';
+import { loadSongForUpload, uploadSongToRoom } from '~/modules/online/client/song-transfer';
+
+/** Transfers the host's pick to the room. Owned above the lobby ↔ song-browser switch: the browser
+ * unmounts the moment a song is picked, and it's the lobby that has to show the transfer through. */
+export default function useSongUpload() {
+  const [state, setState] = useState<'idle' | 'uploading' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const upload = async (song: SongPreview, tolerance: number, difficulty?: string) => {
+    setState('uploading');
+    setError(null);
+    try {
+      const fullSong = await loadSongForUpload(song);
+      await uploadSongToRoom(fullSong, tolerance, difficulty);
+      trackOnlineSongSelected(song.id, song.artist, song.title);
+      setState('idle');
+    } catch (uploadError) {
+      setState('error');
+      setError(uploadError instanceof Error ? uploadError.message : String(uploadError));
+    }
+  };
+
+  return { state, error, upload };
+}
+
+export type SongUpload = ReturnType<typeof useSongUpload>;

--- a/src/routes/online/lobby/customize-modal.tsx
+++ b/src/routes/online/lobby/customize-modal.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+import { MAX_NAME_LENGTH } from '~/consts';
+import { Menu } from '~/modules/elements/akui/menu';
+import { Input } from '~/modules/elements/input';
+import Modal from '~/modules/elements/modal';
+import { PlayerColorPicker } from '~/modules/elements/player-color-picker';
+import useKeyboardNav from '~/modules/hooks/use-keyboard-nav';
+import OnlineClient from '~/modules/online/client/online-client';
+import { OnlineParticipant } from '~/modules/online/protocol/types';
+import { PLAYER_NUMBERS, PlayerNumber } from '~/modules/players/player-number';
+import { setStoredOnlineName } from '~/routes/online/hooks/use-online-name';
+import { BackgroundThemeSetting, useSettingValue } from '~/routes/settings/settings-state';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  self: OnlineParticipant | undefined;
+  participants: OnlineParticipant[];
+}
+
+/** Change your display name and color (colors map to player numbers, one singer each). */
+function CustomizeModal({ open, onClose, self, participants }: Props) {
+  const [name, setName] = useState(self?.name ?? '');
+  const [theme] = useSettingValue(BackgroundThemeSetting);
+
+  useEffect(() => {
+    if (open) setName(self?.name ?? '');
+  }, [open, self?.name]);
+
+  const { register } = useKeyboardNav({ enabled: open, onBackspace: onClose });
+
+  const submitName = () => {
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== self?.name) {
+      setStoredOnlineName(trimmed);
+      OnlineClient.send.room.setName(trimmed);
+    }
+  };
+
+  const close = () => {
+    submitName();
+    onClose();
+  };
+
+  // Picking a color is the whole decision — apply it (along with any name edit) and get out of the
+  // way, rather than asking for a second click on Done to confirm what was already chosen.
+  const pickColor = (playerNumber: PlayerNumber) => {
+    if (playerNumber === self?.playerNumber) return;
+    OnlineClient.send.room.setPlayerNumber(playerNumber);
+    close();
+  };
+
+  const occupants: Partial<Record<PlayerNumber, string>> = {};
+  for (const participant of participants) {
+    if (participant.id !== self?.id) occupants[participant.playerNumber] ??= participant.name;
+  }
+
+  return (
+    <Modal open={open} onClose={close}>
+      {open && (
+        <Menu data-test="online-customize-modal">
+          <Menu.Header>Name &amp; color</Menu.Header>
+          <Input
+            {...register('online-name', () => undefined)}
+            label="Your name"
+            value={name}
+            onChange={setName}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') close();
+            }}
+            maxLength={MAX_NAME_LENGTH}
+            placeholder="Enter your name"
+            data-test="online-lobby-name-input"
+          />
+          <PlayerColorPicker
+            theme={theme}
+            playerNumbers={PLAYER_NUMBERS}
+            selected={self?.playerNumber ?? null}
+            occupants={occupants}
+            onPick={pickColor}
+            disableOccupied
+          />
+          <Menu.Button {...register('customize-done', close)} size="small" data-test="customize-done-button">
+            Done
+          </Menu.Button>
+        </Menu>
+      )}
+    </Modal>
+  );
+}
+
+export default CustomizeModal;

--- a/src/routes/online/lobby/customize-modal.tsx
+++ b/src/routes/online/lobby/customize-modal.tsx
@@ -26,9 +26,8 @@ function CustomizeModal({ open, onClose, self, participants }: Props) {
 
   useEffect(() => {
     if (open) setName(self?.name ?? '');
-  }, [open, self?.name]);
-
-  const { register } = useKeyboardNav({ enabled: open, onBackspace: onClose });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed only when the modal opens; a self?.name change while it's open (e.g. an echo of our own edit) must not clobber what's being typed
+  }, [open]);
 
   const submitName = () => {
     const trimmed = name.trim();
@@ -42,6 +41,8 @@ function CustomizeModal({ open, onClose, self, participants }: Props) {
     submitName();
     onClose();
   };
+
+  const { register } = useKeyboardNav({ enabled: open, onBackspace: close });
 
   // Picking a color is the whole decision — apply it (along with any name edit) and get out of the
   // way, rather than asking for a second click on Done to confirm what was already chosen.

--- a/src/routes/online/lobby/lobby-song-card.tsx
+++ b/src/routes/online/lobby/lobby-song-card.tsx
@@ -48,12 +48,14 @@ function LobbySongCard({ preview, roomCode, onChooseSong, footer }: Props) {
 
   const onVideoStateChange = useCallback(
     (state: VideoState) => {
-      if (state === VideoState.ENDED) {
-        player.current?.seekTo(start);
+      if (state === VideoState.ENDED && video) {
+        // Reload (rather than seekTo) so the endSeconds bound is re-established — a bare seek
+        // doesn't reliably re-arm it, and the preview would play past `end` on the next loop.
+        player.current?.loadVideoById({ videoId: video, startSeconds: start, endSeconds: end });
         player.current?.playVideo();
       }
     },
-    [start],
+    [video, start, end],
   );
 
   return (

--- a/src/routes/online/lobby/lobby-song-card.tsx
+++ b/src/routes/online/lobby/lobby-song-card.tsx
@@ -1,0 +1,129 @@
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+
+import { Button } from '~/modules/elements/akui/button';
+import { Chip } from '~/modules/elements/akui/chip';
+import { Icon } from '~/modules/elements/akui/icon';
+import SongPreviewLayout from '~/modules/elements/song-preview-layout';
+import VideoPlayer, { VideoPlayerRef, VideoState } from '~/modules/elements/video-player/index';
+import { SongHoverPreview } from '~/modules/online/protocol/types';
+import RoomCodePanel from '~/routes/online/lobby/room-code-panel';
+import SongFlag from '~/routes/sing-a-song/song-selection/components/song-card/song-flag';
+
+interface Props {
+  /** What the host is browsing, or the song already selected — null before anything is picked. */
+  preview: SongHoverPreview | null;
+  roomCode: string;
+  /** Host only, and only while nothing is picked — turns the empty thumbnail into the way to pick. */
+  onChooseSong?: () => void;
+  /** The row under the card: the room's singers and what everyone can do about the song. */
+  footer: ReactNode;
+}
+
+/** Same 30s window the song list previews when the host hasn't sent an explicit end. */
+const PREVIEW_LENGTH = 30;
+
+/** The lobby as a song card: the same layout the song list expands a song into, with the room code
+ * under the title and the singers where the mic check sits. */
+function LobbySongCard({ preview, roomCode, onChooseSong, footer }: Props) {
+  const player = useRef<VideoPlayerRef | null>(null);
+  const video = preview?.video;
+  const start = preview?.previewStart ?? 0;
+  const end = preview?.previewEnd ?? start + PREVIEW_LENGTH;
+
+  // The player only exists while there is a video, so each new one starts unready
+  const [playerReady, setPlayerReady] = useState(false);
+  useEffect(() => {
+    if (!video) setPlayerReady(false);
+  }, [video]);
+
+  // Driven by the ref (rather than the `video` prop) so the preview window can be bounded — that's
+  // what makes ENDED fire, which is what loops it, exactly as the song list does. Held until the
+  // player reports itself ready: commands sent before that are posted to an iframe that isn't
+  // listening yet, and are dropped without an error, leaving the thumbnail black for good.
+  useEffect(() => {
+    if (!video || !playerReady) return;
+    player.current?.loadVideoById({ videoId: video, startSeconds: start, endSeconds: end });
+    player.current?.playVideo();
+  }, [video, start, end, playerReady]);
+
+  const onVideoStateChange = useCallback(
+    (state: VideoState) => {
+      if (state === VideoState.ENDED) {
+        player.current?.seekTo(start);
+        player.current?.playVideo();
+      }
+    },
+    [start],
+  );
+
+  return (
+    <SongPreviewLayout
+      expanded
+      title={
+        <span
+          className="typography text-active truncate text-xl leading-tight font-bold sm:text-3xl"
+          data-test="online-host-browsing-title">
+          {preview?.title ?? 'No song yet'}
+        </span>
+      }
+      artist={
+        <span className="typography text-md truncate leading-tight sm:text-xl" data-test="online-host-browsing-artist">
+          {preview?.artist ?? 'The host picks the song'}
+        </span>
+      }
+      underTitle={<RoomCodePanel roomCode={roomCode} className="mt-2 sm:mt-4" />}
+      thumbnail={
+        <div className="relative isolate flex aspect-video w-full items-center justify-center overflow-hidden rounded-xl bg-[#2b2b2b]">
+          {video ? (
+            <VideoPlayer
+              ref={player}
+              video=""
+              width={480}
+              height={270}
+              volume={preview?.volume}
+              disablekb
+              onReady={() => setPlayerReady(true)}
+              onStateChange={onVideoStateChange}
+            />
+          ) : onChooseSong ? (
+            // An empty thumbnail is the most obvious place to look for the song — so it's the button
+            <Button
+              size="small"
+              fullWidth={false}
+              className="w-auto px-6"
+              leftIcon={<Icon icon="ic:baseline-search" size={6} />}
+              onClick={onChooseSong}
+              data-test="thumbnail-choose-song-button">
+              Select song
+            </Button>
+          ) : (
+            <Icon icon="ic:baseline-search" size={12} className="opacity-25" />
+          )}
+        </div>
+      }
+      underThumbnail={
+        preview && (
+          <div className="flex flex-wrap items-center gap-1" data-test="online-host-browsing-details">
+            {preview.language?.length ? (
+              <SongFlag song={{ language: preview.language, artistOrigin: preview.artistOrigin }} chip />
+            ) : null}
+            {preview.year && <Chip>{preview.year}</Chip>}
+            <Chip className="[&_svg]:h-4 [&_svg]:w-4">
+              <Icon icon="ic:baseline-games" width="1rem" height="1rem" />
+              <span>{preview.mode ?? 'Duel'}</span>
+            </Chip>
+            {preview.difficulty && (
+              <Chip className="[&_svg]:h-4 [&_svg]:w-4">
+                <Icon icon="ic:baseline-speed" width="1rem" height="1rem" />
+                <span>{preview.difficulty}</span>
+              </Chip>
+            )}
+          </div>
+        )
+      }
+      footer={footer}
+    />
+  );
+}
+
+export default LobbySongCard;

--- a/src/routes/online/lobby/lobby.tsx
+++ b/src/routes/online/lobby/lobby.tsx
@@ -43,6 +43,8 @@ function Lobby({ roomCode, roomState, song, songError, upload, onChooseSong }: P
   const self = useOnlineSelf();
 
   const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
 
   // Disabled while the customize modal owns the keyboard — otherwise Enter presses there would also
   // trigger the lobby's remembered actions. The confirmations (leave, kick) pause this on their own.
@@ -63,7 +65,13 @@ function Lobby({ roomCode, roomState, song, songError, upload, onChooseSong }: P
   // The host starts the song on their own — everyone confirms readiness on the singing screen after,
   // with the video already loaded, rather than pre-agreeing to it here
   const startGame = () => {
-    void OnlineClient.rpc.room.startGame().catch(console.warn);
+    if (starting) return;
+    setStarting(true);
+    setStartError(null);
+    void OnlineClient.rpc.room
+      .startGame()
+      .catch((error: unknown) => setStartError(error instanceof Error ? error.message : String(error)))
+      .finally(() => setStarting(false));
   };
 
   // The room reports the selected song as the preview once the host stops browsing — fall back to
@@ -154,8 +162,12 @@ function Lobby({ roomCode, roomState, song, songError, upload, onChooseSong }: P
                       : 'Choose song'}
                 </Menu.Button>
               )}
-              {upload.state === 'error' && (
-                <Menu.HelpText data-test="online-upload-error">Song transfer failed: {upload.error}</Menu.HelpText>
+              {(upload.state === 'error' || startError) && (
+                <Menu.HelpText data-test="online-upload-error">
+                  {upload.state === 'error'
+                    ? `Song transfer failed: ${upload.error}`
+                    : `Failed to start: ${startError}`}
+                </Menu.HelpText>
               )}
 
               {/* The host's call alone — everyone else confirms they're ready once the song
@@ -164,8 +176,8 @@ function Lobby({ roomCode, roomState, song, songError, upload, onChooseSong }: P
                 <Menu.Button
                   {...register('start-song', startGame, undefined, true)}
                   data-test="online-start-song-button"
-                  disabled={!self?.connected || upload.state === 'uploading'}>
-                  Start the song!
+                  disabled={!self?.connected || upload.state === 'uploading' || starting}>
+                  {starting ? 'Starting…' : 'Start the song!'}
                 </Menu.Button>
               )}
               {!isHost && roomState.chart && song && (

--- a/src/routes/online/lobby/lobby.tsx
+++ b/src/routes/online/lobby/lobby.tsx
@@ -1,0 +1,215 @@
+import { useState } from 'react';
+
+import { Song } from '~/interfaces';
+import ConfirmModal from '~/modules/elements/akui/confirm-modal';
+import { Icon } from '~/modules/elements/akui/icon';
+import { Menu } from '~/modules/elements/akui/menu';
+import { useBackground } from '~/modules/elements/background-context';
+import MenuWithLogo from '~/modules/elements/menu-with-logo';
+import SongPreviewLayout from '~/modules/elements/song-preview-layout';
+import useBackgroundMusic from '~/modules/hooks/use-background-music';
+import useKeyboardNav from '~/modules/hooks/use-keyboard-nav';
+import useSmoothNavigate from '~/modules/hooks/use-smooth-navigate';
+import {
+  useIsOnlineHost,
+  useOnlineSelf,
+  useOnlineSongPreview,
+  useOnlineSongVotes,
+} from '~/modules/online/client/hooks';
+import OnlineClient from '~/modules/online/client/online-client';
+import { OnlineRoomState, SongHoverPreview, SongVote } from '~/modules/online/protocol/types';
+import { SongUpload } from '~/routes/online/hooks/use-song-upload';
+import CustomizeModal from '~/routes/online/lobby/customize-modal';
+import LobbySongCard from '~/routes/online/lobby/lobby-song-card';
+import ParticipantList from '~/routes/online/lobby/participant-list';
+
+interface Props {
+  roomCode: string;
+  roomState: OnlineRoomState;
+  song: Song | null;
+  songError: string | null;
+  /** The transfer of the host's pick — it starts as the browser closes, so the lobby only reports it. */
+  upload: SongUpload;
+  /** Host only — opens the song browser (its own route, so Back comes back here). */
+  onChooseSong: () => void;
+}
+
+function Lobby({ roomCode, roomState, song, songError, upload, onChooseSong }: Props) {
+  useBackground(true);
+  // The results screen turns the menu music on; the lobby is not a menu, so turn it back off
+  useBackgroundMusic(false);
+  const navigate = useSmoothNavigate();
+  const isHost = useIsOnlineHost();
+  const self = useOnlineSelf();
+
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+
+  // Disabled while the customize modal owns the keyboard — otherwise Enter presses there would also
+  // trigger the lobby's remembered actions. The confirmations (leave, kick) pause this on their own.
+  const { register } = useKeyboardNav({
+    enabled: !customizeOpen,
+  });
+
+  const hostSongPreview = useOnlineSongPreview();
+  const votes = useOnlineSongVotes();
+  const selfId = OnlineClient.getParticipantId();
+  const myVote = hostSongPreview && votes[selfId]?.songId === hostSongPreview.songId ? votes[selfId].vote : null;
+
+  const voteSong = (vote: SongVote) => {
+    if (!hostSongPreview) return;
+    OnlineClient.send.selection.voteSong(hostSongPreview.songId, myVote === vote ? null : vote);
+  };
+
+  // The host starts the song on their own — everyone confirms readiness on the singing screen after,
+  // with the video already loaded, rather than pre-agreeing to it here
+  const startGame = () => {
+    void OnlineClient.rpc.room.startGame().catch(console.warn);
+  };
+
+  // The room reports the selected song as the preview once the host stops browsing — fall back to
+  // the chart anyway so the header never goes blank while that update is in flight.
+  const headerPreview: SongHoverPreview | null =
+    hostSongPreview ??
+    (roomState.chart
+      ? {
+          songId: roomState.chart.songId,
+          artist: roomState.chart.artist,
+          title: roomState.chart.title,
+          video: roomState.chart.video,
+        }
+      : null);
+
+  const leaveRoom = () => {
+    navigate('online/', { room: null });
+  };
+
+  return (
+    // Same card as the expanded song preview — width, background and padding included
+    <MenuWithLogo
+      className="border border-white/10 bg-slate-800 sm:min-h-[72vh] sm:max-w-[min(90vw,72rem)] lg:max-w-[min(90vw,72rem)] 2xl:max-w-[min(90vw,72rem)]"
+      data-test="online-lobby">
+      <LobbySongCard
+        preview={headerPreview}
+        roomCode={roomCode}
+        onChooseSong={isHost && !roomState.chart && upload.state !== 'uploading' ? onChooseSong : undefined}
+        footer={
+          <>
+            <Menu.Divider className="mb-4" />
+
+            {/* The same split the expanded song preview uses for its settings row: singers on
+                the left where the mic check sits, the actions on the right. */}
+            <SongPreviewLayout.Split
+              aside={
+                <ParticipantList roomState={roomState} selfId={selfId} onEdit={() => setCustomizeOpen(true)} canKick />
+              }>
+              {(!roomState.chart || !song || songError) && (
+                <Menu.HelpText data-test="online-selected-song">
+                  {!roomState.chart
+                    ? isHost
+                      ? 'Pick a song to get the party going.'
+                      : hostSongPreview
+                        ? 'The host is browsing — let them know what you think.'
+                        : 'Waiting for the host to pick a song…'
+                    : songError
+                      ? `The song failed to load: ${songError}`
+                      : 'Loading the song…'}
+                </Menu.HelpText>
+              )}
+
+              {/* Singers can react to whatever is on screen — the song the host is browsing and the
+                  one they settled on, so the host can still be talked out of it */}
+              {!isHost && hostSongPreview && (
+                <Menu.ButtonGroup className="w-full gap-2">
+                  {/* The vote is what a singer's lobby is for — leaving isn't, so the focus lands
+                      here as soon as there's something to vote on */}
+                  <Menu.Button
+                    {...register('online-vote-up', () => voteSong('up'), undefined, true)}
+                    size="small"
+                    className={`flex-1 ${myVote === 'up' ? '' : 'opacity-60'}`}
+                    data-test="online-vote-up">
+                    <Icon icon="ic:baseline-thumb-up" size={5} className="mr-1" />
+                    Sing it!
+                  </Menu.Button>
+                  <Menu.Button
+                    {...register('online-vote-down', () => voteSong('down'))}
+                    size="small"
+                    className={`flex-1 ${myVote === 'down' ? '' : 'opacity-60'}`}
+                    data-test="online-vote-down">
+                    <Icon icon="ic:baseline-thumb-down" size={5} className="mr-1" />
+                    Rather not
+                  </Menu.Button>
+                </Menu.ButtonGroup>
+              )}
+
+              {isHost && (
+                <Menu.Button
+                  {...register('choose-song', onChooseSong, undefined, !roomState.chart)}
+                  disabled={upload.state === 'uploading'}
+                  size={roomState.chart ? 'small' : undefined}
+                  data-test="choose-song-button">
+                  {upload.state === 'uploading'
+                    ? 'Transferring song…'
+                    : roomState.chart
+                      ? 'Change song'
+                      : 'Choose song'}
+                </Menu.Button>
+              )}
+              {upload.state === 'error' && (
+                <Menu.HelpText data-test="online-upload-error">Song transfer failed: {upload.error}</Menu.HelpText>
+              )}
+
+              {/* The host's call alone — everyone else confirms they're ready once the song
+                  screen is up and the video has loaded */}
+              {isHost && roomState.chart && song && (
+                <Menu.Button
+                  {...register('start-song', startGame, undefined, true)}
+                  data-test="online-start-song-button"
+                  disabled={!self?.connected || upload.state === 'uploading'}>
+                  Start the song!
+                </Menu.Button>
+              )}
+              {!isHost && roomState.chart && song && (
+                <Menu.HelpText data-test="online-waiting-for-start">
+                  Waiting for the host to start the song…
+                </Menu.HelpText>
+              )}
+
+              {/* Last in the list — leaving is the way out, not something to hit by accident */}
+              <Menu.Divider className="mt-1" />
+              <ConfirmModal
+                title="Leave the room?"
+                description={
+                  isHost
+                    ? 'The room stays open and another singer takes over as host.'
+                    : "You'll need the room code to come back."
+                }
+                onConfirm={leaveRoom}
+                dataTestPrefix="online-leave-confirm"
+                cancelButton={
+                  <ConfirmModal.CancelButton name="stay-in-room">Stay in the room</ConfirmModal.CancelButton>
+                }
+                confirmButton={
+                  <ConfirmModal.ConfirmButton name="confirm-leave-room">Leave room</ConfirmModal.ConfirmButton>
+                }>
+                {(openLeaveConfirm) => (
+                  <Menu.Button {...register('leave-room', openLeaveConfirm)} size="small" data-test="leave-room-button">
+                    Leave room
+                  </Menu.Button>
+                )}
+              </ConfirmModal>
+            </SongPreviewLayout.Split>
+          </>
+        }
+      />
+
+      <CustomizeModal
+        open={customizeOpen}
+        onClose={() => setCustomizeOpen(false)}
+        self={self}
+        participants={roomState.participants}
+      />
+    </MenuWithLogo>
+  );
+}
+
+export default Lobby;

--- a/src/routes/online/lobby/participant-list.tsx
+++ b/src/routes/online/lobby/participant-list.tsx
@@ -1,0 +1,56 @@
+import { OnlineRoomState } from '~/modules/online/protocol/types';
+import { PLAYER_NUMBERS } from '~/modules/players/player-number';
+import ParticipantSlot from '~/routes/online/components/participant-slot';
+import { MicCheckSlotShell } from '~/routes/sing-a-song/song-selection/components/song-settings/mic-check/mic-check-slot';
+
+interface Props {
+  roomState: OnlineRoomState;
+  selfId: string;
+  /** Opens the name/color editor for the own row. */
+  onEdit?: () => void;
+  /** Offer the host the kick (and ban) control on other singers' rows. */
+  canKick?: boolean;
+}
+
+/** The room's singers, using the same rows as the local mic check — a player-colored volume bar
+ * filling in behind the name, with lobby tags (host/disconnected) and actions on the right.
+ * Readiness isn't shown here: it's confirmed on the singing screen once the host starts. */
+function ParticipantList({ roomState, selfId, onEdit, canKick }: Props) {
+  return (
+    <div className="flex flex-col gap-3" data-test="online-participant-list">
+      {PLAYER_NUMBERS.map((playerNumber) => {
+        const participant = roomState.participants.find((p) => p.playerNumber === playerNumber);
+
+        // The room's free seats are shown too, so everyone can see there's still space to join
+        if (!participant) {
+          return (
+            <MicCheckSlotShell
+              key={`empty-${playerNumber}`}
+              data-test={`online-empty-slot-${playerNumber}`}
+              playerNumber={playerNumber}
+              name={<span className="text-base">Free slot</span>}
+              connected={false}
+              volume={{ type: 'none' }}
+            />
+          );
+        }
+
+        return (
+          <ParticipantSlot
+            key={participant.id}
+            data-test={`online-participant-${participant.playerNumber}`}
+            participant={participant}
+            selfId={selfId}
+            hostId={roomState.hostId}
+            showVote
+            showTags
+            onEdit={onEdit}
+            canKick={canKick}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+export default ParticipantList;

--- a/src/routes/online/lobby/room-code-panel.tsx
+++ b/src/routes/online/lobby/room-code-panel.tsx
@@ -1,0 +1,25 @@
+import CopyLinkField from '~/modules/elements/copy-link-field';
+import RoomCode from '~/modules/elements/room-code';
+import buildRoomLink from '~/modules/utils/build-room-link';
+
+interface Props {
+  roomCode: string;
+  className?: string;
+}
+
+/** The room code sitting right under the song's artist/title, with the invite link next to a copy
+ * button — the same shape the remote-mic connection screen uses. */
+function RoomCodePanel({ roomCode, className }: Props) {
+  const link = buildRoomLink('online', roomCode);
+
+  return (
+    <div className={`flex flex-col gap-2 ${className ?? ''}`} data-test="online-invite-link">
+      <span className="typography text-xl">
+        Room code: <RoomCode code={roomCode} className="ml-1" data-test="online-room-code" />
+      </span>
+      <CopyLinkField link={link} inputDataTest="online-invite-link-input" buttonDataTest="copy-room-link-button" />
+    </div>
+  );
+}
+
+export default RoomCodePanel;

--- a/src/routes/online/lobby/song-players-panel.tsx
+++ b/src/routes/online/lobby/song-players-panel.tsx
@@ -1,0 +1,34 @@
+import { Icon } from '~/modules/elements/akui/icon';
+import { useOnlineRoomState } from '~/modules/online/client/hooks';
+import OnlineClient from '~/modules/online/client/online-client';
+import ParticipantSlot from '~/routes/online/components/participant-slot';
+
+/** Shown to the host in the song preview instead of the mic check — the same mic-check rows the
+ * local game uses, driven by each singer's remotely reported volume, plus their thumbs up/down. */
+function OnlineSongPlayersPanel() {
+  const roomState = useOnlineRoomState();
+  const selfId = OnlineClient.getParticipantId();
+
+  const connected = roomState?.participants.filter((participant) => participant.connected) ?? [];
+
+  return (
+    <div className="flex flex-col gap-3" data-test="online-song-players-panel">
+      {connected.map((participant) => (
+        <ParticipantSlot
+          key={participant.id}
+          data-test={`online-song-player-${participant.playerNumber}`}
+          participant={participant}
+          selfId={selfId}
+          showVote
+        />
+      ))}
+      <span className="typography flex items-center gap-1 text-sm opacity-75">
+        They can react with
+        <Icon icon="ic:baseline-thumb-up" size={4} />/<Icon icon="ic:baseline-thumb-down" size={4} /> to the song
+        you&#39;re browsing.
+      </span>
+    </div>
+  );
+}
+
+export default OnlineSongPlayersPanel;

--- a/src/routes/online/setup-wizard.tsx
+++ b/src/routes/online/setup-wizard.tsx
@@ -164,8 +164,9 @@ function CodeStep({
   const { register } = useKeyboardNav({ onBackspace: onBack });
 
   const submit = async () => {
+    if (checking) return;
     const roomCode = code.trim().toLowerCase();
-    if (roomCode.length < 3) {
+    if (roomCode.length < ONLINE_ROOM_CODE_LENGTH) {
       inputRef.current?.triggerValidationError('Enter the room code');
       return;
     }

--- a/src/routes/online/setup-wizard.tsx
+++ b/src/routes/online/setup-wizard.tsx
@@ -1,0 +1,297 @@
+import { AnimatePresence, motion } from 'motion/react';
+import { useRef, useState } from 'react';
+
+import { MAX_NAME_LENGTH } from '~/consts';
+import { Calibration } from '~/modules/calibration/calibration';
+import { Menu } from '~/modules/elements/akui/menu';
+import WizardChecklist, { WizardStepEntry } from '~/modules/elements/akui/wizard-checklist';
+import { Input } from '~/modules/elements/input';
+import MenuWithLogo from '~/modules/elements/menu-with-logo';
+import useKeyboardNav from '~/modules/hooks/use-keyboard-nav';
+import useMicMonitoring from '~/modules/hooks/use-mic-monitoring';
+import { checkRoomExists } from '~/modules/online/client/online-client';
+import { ONLINE_ROOM_CODE_LENGTH } from '~/modules/online/protocol/consts';
+import generateRoomCode from '~/modules/utils/generate-room-code';
+import { CalibrationIntro } from '~/routes/game/singing/calibration-intro';
+import useOnlineName from '~/routes/online/hooks/use-online-name';
+import BuiltIn from '~/routes/select-input/variants/built-in';
+import { IsCalibratedSetting, MicSetupPreferenceSetting, useSettingValue } from '~/routes/settings/settings-state';
+
+/** Step ids double as the checklist ordering — see `stepOrder` below. */
+const STEP = { code: 0, name: 1, mic: 2, calibration: 3 } as const;
+type Step = (typeof STEP)[keyof typeof STEP];
+
+const STEP_LABELS: Record<Step, string> = {
+  [STEP.code]: 'Enter Room Code',
+  [STEP.name]: 'Set Your Name',
+  [STEP.mic]: 'Set Up Microphone',
+  [STEP.calibration]: 'Sync Video With Sound',
+};
+
+// Matches the remote-mic wizard's step crossfade — long enough to read as a transition, short
+// enough never to be waited on
+const STEP_TRANSITION_S = 0.2;
+
+interface Props {
+  /** 'create' opens a brand-new room; 'join' asks for (or confirms) a room code first. */
+  mode: 'create' | 'join';
+  /** Room code when arriving via an invite link — prefills the code step. */
+  joinRoomCode?: string | null;
+  onComplete: (roomCode: string, options: { create: boolean }) => void;
+  onBack: () => void;
+}
+
+/**
+ * Everything that has to happen before entering a room, as the same checklist the remote mic uses:
+ * room code (join only) → name (skipped when remembered) → microphone → calibration (skipped when
+ * already calibrated). Calibrating here rather than in the lobby means readying up is a single click.
+ */
+function OnlineSetupWizard({ mode, joinRoomCode = null, onComplete, onBack }: Props) {
+  const { name: storedName, hasStoredName, setName: persistName } = useOnlineName();
+  const [isCalibrated, setIsCalibrated] = useSettingValue(IsCalibratedSetting);
+
+  // Which steps this singer actually walks through, decided once on mount: a remembered name and an
+  // earlier calibration drop out entirely, and completing a step must not shrink the checklist.
+  const [stepOrder] = useState<Step[]>(() => {
+    const steps: Step[] = [];
+    if (mode === 'join') steps.push(STEP.code);
+    if (!hasStoredName) steps.push(STEP.name);
+    steps.push(STEP.mic);
+    if (!isCalibrated) steps.push(STEP.calibration);
+    return steps;
+  });
+
+  const [step, setStep] = useState<Step>(stepOrder[0]);
+  // The room decision from the code step, applied once the whole wizard finishes
+  const roomTarget = useRef<{ roomCode: string; create: boolean }>(
+    mode === 'create'
+      ? { roomCode: generateRoomCode(ONLINE_ROOM_CODE_LENGTH), create: true }
+      : { roomCode: joinRoomCode ?? '', create: false },
+  );
+
+  const goToNextStep = () => {
+    const next = stepOrder[stepOrder.indexOf(step) + 1];
+    if (next === undefined) {
+      onComplete(roomTarget.current.roomCode, { create: roomTarget.current.create });
+    } else {
+      setStep(next);
+    }
+  };
+
+  const goToPreviousStep = () => {
+    const previous = stepOrder[stepOrder.indexOf(step) - 1];
+    if (previous === undefined) {
+      onBack();
+    } else {
+      setStep(previous);
+    }
+  };
+
+  const onCodeConfirmed = (roomCode: string) => {
+    roomTarget.current = { roomCode, create: false };
+    goToNextStep();
+  };
+
+  const onNameConfirmed = (name: string) => {
+    persistName(name);
+    goToNextStep();
+  };
+
+  const onCalibrated = () => {
+    setIsCalibrated(true);
+    goToNextStep();
+  };
+
+  // The completed room-code entry shows which room is being joined, like the remote mic's game code
+  const getStepLabel = (entry: Step, completed: boolean) =>
+    entry === STEP.code && completed
+      ? `Joining room: ${roomTarget.current.roomCode.toUpperCase()}`
+      : STEP_LABELS[entry];
+
+  const completedSteps: WizardStepEntry[] = stepOrder
+    .slice(0, stepOrder.indexOf(step))
+    .map((entry) => ({ id: entry, label: getStepLabel(entry, true) }));
+
+  return (
+    <MenuWithLogo>
+      <WizardChecklist completedSteps={completedSteps} activeStep={{ id: step, label: getStepLabel(step, false) }} />
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: STEP_TRANSITION_S }}
+          className="flex flex-col gap-4">
+          {step === STEP.code && (
+            <CodeStep initialCode={joinRoomCode ?? ''} onConfirm={onCodeConfirmed} onBack={goToPreviousStep} />
+          )}
+          {step === STEP.name && (
+            <NameStep initialName={storedName} onConfirm={onNameConfirmed} onBack={goToPreviousStep} />
+          )}
+          {step === STEP.mic && (
+            <MicStep
+              onBack={goToPreviousStep}
+              onSave={goToNextStep}
+              // The last step's button says what actually happens next
+              closeButtonText={isCalibrated ? 'Enter the room' : 'Next'}
+            />
+          )}
+          {step === STEP.calibration && <CalibrationStep onDone={onCalibrated} />}
+        </motion.div>
+      </AnimatePresence>
+    </MenuWithLogo>
+  );
+}
+
+/** Room code entry — verified against the server before moving on, so a typo is caught here. */
+function CodeStep({
+  initialCode,
+  onConfirm,
+  onBack,
+}: {
+  initialCode: string;
+  onConfirm: (roomCode: string) => void;
+  onBack: () => void;
+}) {
+  const [code, setCode] = useState(initialCode);
+  const [checking, setChecking] = useState(false);
+  const inputRef = useRef<{
+    element: HTMLInputElement | null;
+    triggerValidationError: (message: string) => void;
+  } | null>(null);
+
+  const { register } = useKeyboardNav({ onBackspace: onBack });
+
+  const submit = async () => {
+    const roomCode = code.trim().toLowerCase();
+    if (roomCode.length < 3) {
+      inputRef.current?.triggerValidationError('Enter the room code');
+      return;
+    }
+    setChecking(true);
+    const exists = await checkRoomExists(roomCode);
+    setChecking(false);
+    if (!exists) {
+      inputRef.current?.triggerValidationError('This room does not exist');
+      return;
+    }
+    onConfirm(roomCode);
+  };
+
+  return (
+    <>
+      <Menu.HelpText>Ask the host for the code shown in their room.</Menu.HelpText>
+      <Input
+        {...register('online-room-code', () => undefined)}
+        className="[&_input]:text-center [&_input]:tracking-[1rem] [&_input]:uppercase"
+        label="Room code"
+        value={code}
+        onChange={setCode}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') void submit();
+        }}
+        maxLength={ONLINE_ROOM_CODE_LENGTH}
+        placeholder="_____"
+        autoCapitalize="characters"
+        autoComplete="off"
+        ref={inputRef}
+        data-test="join-room-code-input"
+      />
+      <Menu.Button
+        {...register('join-room-button', () => void submit())}
+        disabled={checking}
+        data-test="join-room-button">
+        {checking ? 'Checking the room…' : 'Join a room'}
+      </Menu.Button>
+      <Menu.Divider />
+      <Menu.Button {...register('back-button', onBack)} size="small" data-test="back-button">
+        Back
+      </Menu.Button>
+    </>
+  );
+}
+
+function NameStep({
+  initialName,
+  onConfirm,
+  onBack,
+}: {
+  initialName: string;
+  onConfirm: (name: string) => void;
+  onBack: () => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const { register } = useKeyboardNav({ onBackspace: onBack });
+
+  const submit = () => {
+    if (name.trim()) onConfirm(name);
+  };
+
+  return (
+    <>
+      <Input
+        {...register('online-name', submit)}
+        label="Your name"
+        value={name}
+        onChange={setName}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') submit();
+        }}
+        maxLength={MAX_NAME_LENGTH}
+        placeholder="Enter your name"
+        data-test="online-name-input"
+      />
+      <Menu.Button {...register('next-step-button', submit)} disabled={!name.trim()} data-test="next-step-button">
+        Next
+      </Menu.Button>
+      <Menu.Divider />
+      <Menu.Button {...register('back-button', onBack)} size="small" data-test="back-button">
+        Back
+      </Menu.Button>
+    </>
+  );
+}
+
+/** Microphone setup — reuses the "computer's built-in microphone" flow from input selection. */
+function MicStep({
+  onBack,
+  onSave,
+  closeButtonText,
+}: {
+  onBack: () => void;
+  onSave: () => void;
+  closeButtonText: string;
+}) {
+  useMicMonitoring();
+
+  const save = () => {
+    // Mark mic setup as done so e.g. the song-settings step shows Play instead of "Setup mics"
+    MicSetupPreferenceSetting.set('built-in');
+    onSave();
+  };
+
+  return (
+    <BuiltIn
+      onSetupComplete={() => undefined}
+      onBack={onBack}
+      onSave={save}
+      changePreference={() => undefined}
+      closeButtonText={closeButtonText}
+      onlineSetup
+    />
+  );
+}
+
+/** One-time audio calibration, moved ahead of the lobby so readying up never interrupts it. */
+function CalibrationStep({ onDone }: { onDone: () => void }) {
+  const [showIntro, setShowIntro] = useState(true);
+
+  return showIntro ? (
+    <CalibrationIntro onContinue={() => setShowIntro(false)} />
+  ) : (
+    <Calibration onSave={onDone} onClose={() => setShowIntro(true)} saveLabel="Looks good, enter the room" />
+  );
+}
+
+export default OnlineSetupWizard;

--- a/src/routes/sing-a-song/song-selection/components/song-preview.tsx
+++ b/src/routes/sing-a-song/song-selection/components/song-preview.tsx
@@ -106,13 +106,15 @@ export default function SongPreviewComponent({
   const onVideoStateChange = useCallback(
     (state: VideoState) => {
       if (state === VideoState.ENDED) {
-        player.current?.seekTo(start);
+        // Reload (rather than seekTo) so the endSeconds bound is re-established — a bare seek
+        // doesn't reliably re-arm it, and the preview would play past `previewEnd` on the next loop.
+        player.current?.loadVideoById({ videoId, startSeconds: previewStart, endSeconds: previewEnd });
         player.current?.playVideo();
       } else if (state === VideoState.PLAYING) {
         setShowVideo(true);
       }
     },
-    [start],
+    [videoId, previewStart, previewEnd],
   );
 
   const backButton = (


### PR DESCRIPTION
## Summary
- Adds `OnlineSetupWizard` (room create/join → name → mic setup) and the lobby screen (`lobby.tsx`) with its song card, participant list, room-code panel, and song/players panel.
- Adds the shared `ParticipantSlot`/`ParticipantBadges`/`KickPlayer` components, used here by the lobby and reused by the singing overlays in the next PR.
- Adds the `use-online-name` and `use-song-upload` hooks backing the wizard and lobby.

Stack: **6 of 8**. Depends on #617.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an online setup wizard for creating or joining rooms, including room verification, name entry, microphone setup, and audio calibration.
  * Added a complete online lobby with participant management, host controls, song browsing, uploads, voting, previews, and leave-room confirmation.
  * Added room-code sharing with copyable invite links.
  * Added participant customization for display names and colors.
  * Added controls to remove participants and display connection, voting, and latency status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->