### PR TITLE
fix(song-preview): stick play/setup mics buttons to bottom on mobile

### DIFF
--- a/src/routes/sing-a-song/song-selection/components/song-settings/game-settings.tsx
+++ b/src/routes/sing-a-song/song-selection/components/song-settings/game-settings.tsx
@@ -162,27 +162,32 @@ export default function GameSettings({ songPreview, onNextStep, keyboardControl,
             );
           })}
         {multipleTracks && <hr />}
-        {!online && (
-          <NavButton
-            name="select-inputs-button"
-            size="small"
-            className="mobile:px-6"
-            remoteIcon="settings"
-            onClick={() => setShowModal(true)}>
-            Setup mics
-          </NavButton>
-        )}
-        {(areInputsConfigured || online !== null) && (
-          <NavButton
-            name="play-song-button"
-            size="large"
-            className="mobile:px-10 mobile:h-10 mobile:text-md px-20 py-1"
-            remoteIcon="play"
-            isDefault
-            onClick={handlePlay}>
-            Play
-          </NavButton>
-        )}
+        {/* Sticky on mobile — the expanded card scrolls there, so pin play/setup mics to the
+            bottom of the viewport instead of letting them scroll out of reach. Desktop's card
+            never scrolls (sm:overflow-hidden), so the bar reverts to normal flow there. */}
+        <div className="sticky bottom-0 z-10 -mx-3 flex flex-col gap-3 bg-slate-800 px-3 pt-2 pb-3 sm:static sm:mx-0 sm:gap-4 sm:bg-transparent sm:p-0">
+          {!online && (
+            <NavButton
+              name="select-inputs-button"
+              size="small"
+              className="mobile:px-6"
+              remoteIcon="settings"
+              onClick={() => setShowModal(true)}>
+              Setup mics
+            </NavButton>
+          )}
+          {(areInputsConfigured || online !== null) && (
+            <NavButton
+              name="play-song-button"
+              size="large"
+              className="mobile:px-10 mobile:h-10 mobile:text-md px-20 py-1"
+              remoteIcon="play"
+              isDefault
+              onClick={handlePlay}>
+              Play
+            </NavButton>
+          )}
+        </div>
         {/* Remote-only: the expanded song card has no back button on desktop (only the Backspace
             handler and a mobile-only one in song-preview), so the phone would otherwise have no way
             out of this screen once mirrored. */}

--- a/src/routes/sing-a-song/song-selection/components/song-settings/game-settings.tsx
+++ b/src/routes/sing-a-song/song-selection/components/song-settings/game-settings.tsx
@@ -162,32 +162,38 @@ export default function GameSettings({ songPreview, onNextStep, keyboardControl,
             );
           })}
         {multipleTracks && <hr />}
-        {/* Sticky on mobile — the expanded card scrolls there, so pin play/setup mics to the
-            bottom of the viewport instead of letting them scroll out of reach. Desktop's card
-            never scrolls (sm:overflow-hidden), so the bar reverts to normal flow there. */}
-        <div className="sticky bottom-0 z-10 -mx-3 flex flex-col gap-3 bg-slate-800 px-3 pt-2 pb-3 sm:static sm:mx-0 sm:gap-4 sm:bg-transparent sm:p-0">
-          {!online && (
-            <NavButton
-              name="select-inputs-button"
-              size="small"
-              className="mobile:px-6"
-              remoteIcon="settings"
-              onClick={() => setShowModal(true)}>
-              Setup mics
-            </NavButton>
-          )}
-          {(areInputsConfigured || online !== null) && (
-            <NavButton
-              name="play-song-button"
-              size="large"
-              className="mobile:px-10 mobile:h-10 mobile:text-md px-20 py-1"
-              remoteIcon="play"
-              isDefault
-              onClick={handlePlay}>
-              Play
-            </NavButton>
-          )}
-        </div>
+        {!online && (
+          <NavButton
+            name="select-inputs-button"
+            size="small"
+            className="mobile:px-6"
+            remoteIcon="settings"
+            onClick={() => setShowModal(true)}>
+            Setup mics
+          </NavButton>
+        )}
+        {(areInputsConfigured || online !== null) && (
+          <>
+            {/* Fixed on mobile — the expanded card scrolls there, and its natural spot in the list
+                can sit below the fold, so `sticky` alone wouldn't show it until the user scrolled
+                down past it. Pin it to the viewport instead so it's visible from the start.
+                Desktop's card never scrolls (sm:overflow-hidden), so this reverts to normal flow. */}
+            <div className="fixed inset-x-px bottom-0 z-40 flex h-[60px] items-center bg-slate-800 px-3 sm:static sm:h-auto sm:bg-transparent sm:p-0">
+              <NavButton
+                name="play-song-button"
+                size="large"
+                className="mobile:px-10 mobile:h-10 mobile:text-md w-full px-20 py-1 sm:w-auto"
+                remoteIcon="play"
+                isDefault
+                onClick={handlePlay}>
+                Play
+              </NavButton>
+            </div>
+            {/* Spacer reserving the fixed bar's height so it doesn't cover the last bit of
+                scrollable content (e.g. the mic check panels) underneath it. */}
+            <div aria-hidden className="h-[60px] sm:hidden" />
+          </>
+        )}
         {/* Remote-only: the expanded song card has no back button on desktop (only the Backspace
             handler and a mobile-only one in song-preview), so the phone would otherwise have no way
             out of this screen once mirrored. */}


### PR DESCRIPTION
## Summary
- Extended song preview scrolls on mobile; play/setup mics buttons could scroll out of view.
- Wraps them in a `sticky bottom-0` container (mobile), `sm:static` on desktop where the card doesn't scroll.

## Test plan
- [x] Verified via Storybook `Song Selection/SongPreview - Expanded` story at mobile viewport (375px, constrained height): buttons stay pinned to bottom edge with matching background while scrolling.
- [x] `pnpm type-check`, `pnpm test:staged`, `pnpm knip` (pre-commit hooks) passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the mobile song settings layout by placing the Play button in a fixed bottom bar.
  * Added spacing to prevent the bottom bar from covering page content.
  * Restored the button to the standard page layout with transparent styling on desktop screens.
  * Preserved existing button behavior and availability conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->