### PR TITLE
Unify modal background/border styling

### DIFF
--- a/src/modules/elements/akui/bottom-sheet.tsx
+++ b/src/modules/elements/akui/bottom-sheet.tsx
@@ -31,7 +31,7 @@ export function BottomSheet({ open, onClose, title, children }: BottomSheetProps
             animate={{ y: 0 }}
             exit={{ y: '100%' }}
             transition={{ type: 'spring', damping: 30, stiffness: 300 }}
-            className="fixed right-0 bottom-0 left-0 z-[20003] rounded-t-2xl bg-black/95"
+            className="fixed right-0 bottom-0 left-0 z-[20003] rounded-t-2xl border border-white/10 bg-slate-800"
             style={{ paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))' }}>
             {/* Handle bar */}
             <div className="flex justify-center pt-3 pb-2">

--- a/src/modules/elements/akui/confirm-modal.tsx
+++ b/src/modules/elements/akui/confirm-modal.tsx
@@ -170,10 +170,7 @@ function ConfirmModalRoot({
           <ConfirmModalContext value={{ register, confirm, cancel }}>
             {/* The same surface the screens underneath are made of (the lobby card, the pause menu),
                 so a confirmation reads as one of them rather than a system dialog. */}
-            <Menu
-              spacing="tight"
-              className="border border-white/10 bg-slate-800"
-              data-test={dataTestPrefix ? `${dataTestPrefix}-modal` : undefined}>
+            <Menu spacing="tight" modal data-test={dataTestPrefix ? `${dataTestPrefix}-modal` : undefined}>
               <Menu.Header>{title}</Menu.Header>
               <Menu.HelpText>{description}</Menu.HelpText>
               <Menu.ButtonGroup className="flex-col gap-2 sm:flex-row sm:justify-end">

--- a/src/modules/elements/akui/menu.tsx
+++ b/src/modules/elements/akui/menu.tsx
@@ -20,11 +20,14 @@ const MenuSubHeader = twc(Typography)`text-lg`;
 interface MenuProps extends PropsWithChildren, Omit<HTMLProps<HTMLDivElement>, 'title'> {
   title?: ReactNode;
   spacing?: 'regular' | 'tight';
+  /** The surface modal content is built from — border + slate-800 background, so it reads as part
+   * of the app rather than a system dialog. Set on the top-level `Menu` a `Modal` wraps. */
+  modal?: boolean;
 }
-export const Menu = ({ title, children, className, spacing = 'regular', ref, ...props }: MenuProps) => (
+export const Menu = ({ title, children, className, spacing = 'regular', modal = false, ref, ...props }: MenuProps) => (
   <MenuContainer
     {...props}
-    className={`${className} ${spacing === 'tight' ? 'gap-2 p-4' : 'gap-4 p-4 sm:p-7'}`}
+    className={`${modal ? 'border border-white/10 bg-slate-800 ' : ''}${className ?? ''} ${spacing === 'tight' ? 'gap-2 p-4' : 'gap-4 p-4 sm:p-7'}`}
     ref={ref}>
     {title && <MenuHeader>{title}</MenuHeader>}
     {children}

--- a/src/modules/toolbar/qr-code-modal.tsx
+++ b/src/modules/toolbar/qr-code-modal.tsx
@@ -17,7 +17,7 @@ function QRCodeModal({ closeModal, open }: Props) {
 
   return (
     <Modal onClose={closeModal} open={open}>
-      <Menu>
+      <Menu modal>
         <ConnectRemoteMic />
         <Menu.Button {...register('quick-connect-close', closeModal)} size="small">
           Close

--- a/src/routes/game/singing/game-overlay/components/pause-menu.tsx
+++ b/src/routes/game/singing/game-overlay/components/pause-menu.tsx
@@ -65,7 +65,7 @@ const PauseMenuContent = ({ onResume, onExit, onRestart }: Omit<Props, 'open'>) 
     <>
       {!rateSongOpen && (
         <KeyboardNavContext value={register}>
-          <Menu>
+          <Menu modal>
             {/* Resume starts playback again, so it reads as "play" rather than a generic back arrow. */}
             <NavButton name="button-resume-song" remoteIcon="play" onClick={onResume} ref={menuRef}>
               Resume song

--- a/src/routes/game/singing/singing.tsx
+++ b/src/routes/game/singing/singing.tsx
@@ -98,7 +98,7 @@ function Singing({ songPreview, singSetup, returnToSongSelection, restartSong }:
             </span>
             <Modal open={showCalibration}>
               {showCalibration && (
-                <Menu>
+                <Menu modal>
                   {showCalibrationIntro ? (
                     <CalibrationIntro onContinue={() => setShowCalibrationIntro(false)} />
                   ) : (

--- a/src/routes/online/lobby/customize-modal.tsx
+++ b/src/routes/online/lobby/customize-modal.tsx
@@ -60,7 +60,7 @@ function CustomizeModal({ open, onClose, self, participants }: Props) {
   return (
     <Modal open={open} onClose={close}>
       {open && (
-        <Menu data-test="online-customize-modal">
+        <Menu modal data-test="online-customize-modal">
           <Menu.Header>Name &amp; color</Menu.Header>
           <Input
             {...register('online-name', () => undefined)}

--- a/src/routes/online/singing/pause-overlay.tsx
+++ b/src/routes/online/singing/pause-overlay.tsx
@@ -63,7 +63,7 @@ function PauseOverlay({ pause, resumeCountdownEndsAt, onResume, isHost, hostId, 
   return (
     <Modal open>
       <KeyboardNavContext value={register}>
-        <Menu data-test="online-pause-overlay">
+        <Menu modal data-test="online-pause-overlay">
           <Menu.Header>
             {pause.reason === 'buffering' ? `Paused — ${pause.name}'s video is buffering` : `Paused by ${pause.name}`}
           </Menu.Header>

--- a/src/routes/remote-mic/components/rename-modal.tsx
+++ b/src/routes/remote-mic/components/rename-modal.tsx
@@ -30,7 +30,7 @@ export default function RenameModal({ open, currentName, onClose, onSave }: Prop
 
   return (
     <Modal open={open} onClose={onClose} data-test="rename-modal" withPortal>
-      <Menu>
+      <Menu modal>
         <Menu.Header>Change your name</Menu.Header>
         <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
           <Input

--- a/src/routes/remote-mic/panels/microphone/connection-wizard/step-enter-code.tsx
+++ b/src/routes/remote-mic/panels/microphone/connection-wizard/step-enter-code.tsx
@@ -147,7 +147,7 @@ export default function StepEnterCode({
         </form>
       </div>
       <Modal open={shouldShowError} onClose={() => setErrorReset(true)} data-test="connection-error-modal" withPortal>
-        <Menu>
+        <Menu modal>
           <Menu.Header>Couldn&#39;t connect</Menu.Header>
           <Typography>
             {roomId ? (

--- a/src/routes/remote-mic/panels/microphone/remote-controls.tsx
+++ b/src/routes/remote-mic/panels/microphone/remote-controls.tsx
@@ -127,7 +127,7 @@ function TextControl({ control }: { control: Extract<ControlDescriptor, { type: 
           fade, which is no loss for a small utility dialog. */}
       {open && (
         <Modal open onClose={() => setOpen(false)} withPortal>
-          <MenuContainer className="gap-2.5">
+          <MenuContainer className="gap-2.5" modal>
             <Menu.Header>{control.label}</Menu.Header>
             <Input
               focused={false}

--- a/src/routes/remote-mic/panels/remote-settings.tsx
+++ b/src/routes/remote-mic/panels/remote-settings.tsx
@@ -56,7 +56,7 @@ function RemoteSettings({ setIsKeepAwakeOn, monitoringStarted, isKeepAwakeOn }: 
       )}
       {permissions !== 'write' && <MicrophoneSettings />}
       <Modal onClose={() => setOpenedPanel(null)} open={openedPanel !== null && permissions === 'write'}>
-        <MenuContainer>
+        <MenuContainer modal>
           <Menu.Header>{openedPanel === 'microphone' ? 'Microphone settings' : 'Manage game'}</Menu.Header>
           {openedPanel === 'microphone' && <MicrophoneSettings />}
           {openedPanel === 'manage' && (

--- a/src/routes/remote-mic/panels/remote-song-list/language-filter.tsx
+++ b/src/routes/remote-mic/panels/remote-song-list/language-filter.tsx
@@ -41,7 +41,7 @@ export default function LanguageFilter({ children, languageList, excludedLanguag
     <>
       <Modal onClose={handleClose} open={open}>
         {open && (
-          <Menu data-test="languages-container" spacing="tight">
+          <Menu modal data-test="languages-container" spacing="tight">
             {filteredLanguageList.map(({ name, count }) => {
               const isExcluded = excludedLanguages.length && excludedLanguages.includes(name);
               return (

--- a/src/routes/select-input/select-input-modal.tsx
+++ b/src/routes/select-input/select-input-modal.tsx
@@ -12,7 +12,7 @@ export default function SelectInputModal({ onClose, closeButtonText, open }: Pro
   return (
     <Modal onClose={onClose} open={open}>
       {open && (
-        <MenuContainer>
+        <MenuContainer modal>
           <SelectInputView
             smooth={false}
             onBack={onClose}


### PR DESCRIPTION
## Summary
- Several app modals (QR code, rename, connection error, language filter, remote settings, control-value, pause menus, calibration, customize) lacked the `slate-800` background + `white/10` border that `ConfirmModal` and the online lobby already used, so they read as floating content instead of part of the app.
- Added a `modal` boolean prop to `Menu` (`src/modules/elements/akui/menu.tsx`) that applies the shared surface styling, and switched every modal's content wrapper over to it instead of duplicated classNames.
- Aligned `BottomSheet`'s body background/border to the same surface, covering its several call sites (player color picker, playlist, language picker, manage players) in one place.

## Test plan
- [x] \`pnpm type-check\`
- [x] pre-commit lint/format/staged-tests hook passed
- [ ] Manual visual check in browser (blocked in this session — no accessible preview server)