### PR TITLE
fix(online): live volume meters, consistent mic monitoring, real first place

### DIFF
--- a/src/modules/elements/volume-indicator.tsx
+++ b/src/modules/elements/volume-indicator.tsx
@@ -3,6 +3,7 @@ import tinycolor from 'tinycolor2';
 
 import styles from '~/modules/game-engine/drawing/styles';
 import { usePlayerMicData } from '~/modules/hooks/players/use-player-mic';
+import { ONLINE_STATS_PUBLISH_MS } from '~/modules/online/protocol/consts';
 import { PlayerNumber } from '~/modules/players/player-number';
 import { twx } from '~/utils/twx';
 
@@ -39,6 +40,9 @@ export const VolumeIndicator = ({ volume, playerNumber, ref, ...rest }: Props) =
         className="h-full w-full origin-right"
         style={{
           transform: `scaleX(${percent})`,
+          // Reported levels land a few times a second, which without this reads as a bar hopping
+          // between positions — a linear tween over one reporting interval turns it into a meter
+          transition: `transform ${ONLINE_STATS_PUBLISH_MS}ms linear`,
           background: `linear-gradient(270deg, rgba(${color}, 1) 0%, rgba(${color}, 0) 100%)`,
         }}
       />

--- a/src/modules/hooks/use-mic-monitoring.ts
+++ b/src/modules/hooks/use-mic-monitoring.ts
@@ -7,8 +7,14 @@ import InputManager from '~/modules/game-engine/input/input-manager';
  * have data. Monitoring that was already running before the mount is left alone on unmount —
  * these screens are nested (input setup inside the online wizard inside a room), and the innermost
  * one must not tear down a pipeline it didn't start.
+ *
+ * `reassertOn` is for screens that stay mounted across changes that can leave the pipeline behind —
+ * an online room lives through every phase, and a singer who picks their mic after monitoring
+ * started (joining via an invite link runs the setup wizard inside the room) would otherwise be
+ * monitored with the input they had at mount. Changing it re-runs `startMonitoring()`, which is
+ * idempotent per device: it picks up inputs added since, and never tears a running one down.
  */
-export default function useMicMonitoring() {
+export default function useMicMonitoring(reassertOn?: unknown) {
   useEffect(() => {
     const wasMonitoring = InputManager.monitoringStarted();
     const startPromise = InputManager.startMonitoring();
@@ -23,4 +29,9 @@ export default function useMicMonitoring() {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (reassertOn === undefined) return;
+    void InputManager.startMonitoring();
+  }, [reassertOn]);
 }

--- a/src/modules/online/client/hooks.ts
+++ b/src/modules/online/client/hooks.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import InputManager from '~/modules/game-engine/input/input-manager';
 import { createSubscriptionHook } from '~/modules/network/rpc/use-subscription-factory';
 import OnlineClient, { OnlineConnectionStatus } from '~/modules/online/client/online-client';
+import { ONLINE_STATS_REPORT_MS } from '~/modules/online/protocol/consts';
 import {
   LeaderboardEntry,
   OnlineRoomState,
@@ -37,14 +38,45 @@ export const useOnlineSongVotes = (): SongVotes => useOnlineSubscription('song-v
 /** Live ping/volume per participant, pushed (coalesced) on the 'player-stats' channel. */
 export const useOnlinePlayersStats = (): PlayersStats => useOnlineSubscription('player-stats') ?? NO_PLAYERS_STATS;
 
-/** Periodically reports this singer's ping and mic volume to the room. */
+/** Volume steps smaller than this don't move the bar by a visible amount — used to skip reports
+ * that would tell the room nothing (a silent singer reports 0 once and then goes quiet). */
+const VOLUME_REPORT_EPSILON = 0.0005;
+
+/** How often a singer whose volume isn't moving still reports, to keep their ping fresh. */
+const STATS_KEEPALIVE_MS = 1_500;
+
+/** The mic is sampled far faster than it's reported, and the peak of the samples is what goes out —
+ * a single instantaneous reading every ~300ms would alias the loud parts away. */
+const VOLUME_SAMPLE_MS = 50;
+
+/** Periodically reports this singer's ping and mic volume to the room, at the same rate the room
+ * re-broadcasts them, so everyone else's volume bar moves like a meter instead of a slideshow. */
 export const useReportPlayerStats = (enabled: boolean, playerNumber: PlayerNumber) => {
   useEffect(() => {
     if (!enabled) return;
+    let peakVolume = 0;
+    let lastSentVolume: number | null = null;
+    let windowStartedAt = 0;
+    let lastSentAt = 0;
     const interval = setInterval(() => {
-      const volume = InputManager.getPlayerVolume(playerNumber) ?? 0;
+      peakVolume = Math.max(peakVolume, InputManager.getPlayerVolume(playerNumber) ?? 0);
+
+      const now = Date.now();
+      if (now - windowStartedAt < ONLINE_STATS_REPORT_MS) return;
+      const volume = peakVolume;
+      windowStartedAt = now;
+      peakVolume = 0;
+
+      // Reporting three times a second is only cheap while it stays quiet when the volume doesn't
+      // move — a singer sitting silent then costs one message per keepalive, which is also what
+      // refreshes their ping (that one never settles, so it can't gate the skip itself).
+      const volumeMoved = lastSentVolume === null || Math.abs(volume - lastSentVolume) >= VOLUME_REPORT_EPSILON;
+      if (!volumeMoved && now - lastSentAt < STATS_KEEPALIVE_MS) return;
+
+      lastSentVolume = volume;
+      lastSentAt = now;
       OnlineClient.send.room.reportStats(OnlineClient.getLatency(), volume);
-    }, 1_500);
+    }, VOLUME_SAMPLE_MS);
     return () => clearInterval(interval);
   }, [enabled, playerNumber]);
 };

--- a/src/modules/online/protocol/consts.ts
+++ b/src/modules/online/protocol/consts.ts
@@ -29,8 +29,14 @@ export const ONLINE_DRIFT_THRESHOLD_MS = 500;
 /** Leaderboard broadcasts are coalesced so subscribers get at most one update per this interval. */
 export const ONLINE_LEADERBOARD_PUBLISH_MS = 500;
 
-/** Player-stats (ping/volume) broadcasts are coalesced to at most one per this interval. */
-export const ONLINE_STATS_PUBLISH_MS = 1_000;
+/** Player-stats (ping/volume) broadcasts are coalesced to at most one per this interval. Fast
+ * enough for the volume bars to read as live meters (~3 updates/s) rather than a slideshow — the
+ * payload is a couple of numbers per singer, and silent singers stop reporting altogether. */
+export const ONLINE_STATS_PUBLISH_MS = 300;
+
+/** How often each singer samples their mic volume and reports it (with their ping) to the room.
+ * Matches the broadcast interval — sampling faster would only be coalesced away. */
+export const ONLINE_STATS_REPORT_MS = 300;
 
 /** How long the room waits for final scores after the host ends the game before forcing results. */
 export const ONLINE_FORCE_RESULTS_MS = 5_000;

--- a/src/modules/online/protocol/room-logic.test.ts
+++ b/src/modules/online/protocol/room-logic.test.ts
@@ -16,6 +16,7 @@ import {
   ONLINE_RESUME_COUNTDOWN_MS,
   ONLINE_ROOM_TTL_MS,
   ONLINE_START_LEAD_MS,
+  ONLINE_STATS_PUBLISH_MS,
 } from '~/modules/online/protocol/consts';
 import { OnlinePersistedState, OnlineRoomLogic } from '~/modules/online/protocol/room-logic';
 import { WireDetailedScore } from '~/modules/online/protocol/types';
@@ -134,7 +135,7 @@ describe('participants', () => {
     // leading publish only, the second report waits for the cooldown
     expect(room.published['player-stats']).toHaveLength(1);
 
-    vi.advanceTimersByTime(1_000);
+    vi.advanceTimersByTime(ONLINE_STATS_PUBLISH_MS);
     expect(room.published['player-stats']).toHaveLength(2);
     expect(room.published['player-stats'].at(-1)).toEqual({
       p1: { ping: 42, volume: 0.01 },

--- a/src/routes/game/singing/game-overlay/game-overlay.tsx
+++ b/src/routes/game/singing/game-overlay/game-overlay.tsx
@@ -5,6 +5,7 @@ import { VideoPlayerRef, VideoState } from '~/modules/elements/video-player/inde
 import CanvasDrawing from '~/modules/game-engine/drawing/index';
 import fragShader from '~/modules/game-engine/drawing/shaders/shader.frag?raw';
 import vertShader from '~/modules/game-engine/drawing/shaders/shader.vert?raw';
+import { PlayerNumber } from '~/modules/players/player-number';
 import PlayersManager from '~/modules/players/players-manager';
 import tuple from '~/modules/utils/tuple';
 import SkipIntro from '~/routes/game/singing/game-overlay/components/skip-intro';
@@ -32,6 +33,10 @@ interface Props {
   skipIntroEnabled?: boolean;
   /** Online mode: routes the skip through the room server so it applies to everyone. */
   onSkipIntro?: (targetTimeSec: number) => void;
+  /** Online mode: the player number leading the room, or null while nobody leads it (a tie, or no
+   * scores yet). The local game leaves this undefined and derives the medal from the players on this
+   * device — in a room that is only ever this singer, so everyone would be crowned first. */
+  leadingPlayerNumber?: PlayerNumber | null;
   onOpenPauseMenu?: () => void;
 }
 
@@ -51,6 +56,7 @@ const GameOverlay = forwardRef(function (
     duration,
     skipIntroEnabled = true,
     onSkipIntro,
+    leadingPlayerNumber,
   }: Props,
   fRef,
 ) {
@@ -169,6 +175,7 @@ const GameOverlay = forwardRef(function (
                   tuple([player.number, GameState.getPlayerScore(player.number)]),
                 );
                 const { score, isFirst } = getPlayerScoreData(scores, player.number);
+                const isLeading = leadingPlayerNumber === undefined ? isFirst : leadingPlayerNumber === player.number;
 
                 return (
                   <span
@@ -178,8 +185,8 @@ const GameOverlay = forwardRef(function (
                     data-score={Math.floor(score)}>
                     <ScoreText score={score} />
                     <div
-                      className={`mobile:top-6 mobile:text-lg absolute top-10 rotate-12 text-xl transition-all duration-200 ${isFirst ? '-right-2' : '-right-36'}`}>
-                      {isFirst ? <div className="motion-preset-pulse-sm opacity-75">🥇</div> : '🥇'}
+                      className={`mobile:top-6 mobile:text-lg absolute top-10 rotate-12 text-xl transition-all duration-200 ${isLeading ? '-right-2' : '-right-36'}`}>
+                      {isLeading ? <div className="motion-preset-pulse-sm opacity-75">🥇</div> : '🥇'}
                     </div>
                   </span>
                 );

--- a/src/routes/game/singing/player.tsx
+++ b/src/routes/game/singing/player.tsx
@@ -15,6 +15,7 @@ import VideoPlayer, { VideoPlayerRef, VideoState } from '~/modules/elements/vide
 import useKeyboard from '~/modules/hooks/use-keyboard';
 import useKeyboardHelp from '~/modules/hooks/use-keyboard-help';
 import usePrevious from '~/modules/hooks/use-previous';
+import { PlayerNumber } from '~/modules/players/player-number';
 import { FeatureFlags } from '~/modules/utils/feature-flags';
 import useFeatureFlag from '~/modules/utils/use-feature-flag';
 import { useVideoPlayer } from '~/routes/game/singing/hooks/use-video-player';
@@ -42,6 +43,8 @@ interface Props extends Omit<ComponentProps<'div'>, 'ref'>, RefAttributes<Player
   skipIntroEnabled?: boolean;
   /** Online mode: routes the skip through the room server so it applies to everyone. */
   onSkipIntro?: (targetTimeSec: number) => void;
+  /** Online mode: who leads the room, for the first-place medal — see GameOverlay's prop. */
+  leadingPlayerNumber?: PlayerNumber | null;
 }
 
 export interface PlayerRef {
@@ -82,6 +85,7 @@ function Player({
   pauseMenu = false,
   skipIntroEnabled = true,
   onSkipIntro,
+  leadingPlayerNumber,
   ref,
   ...restProps
 }: Props) {
@@ -206,6 +210,7 @@ function Player({
             videoPlayerRef={player}
             skipIntroEnabled={skipIntroEnabled}
             onSkipIntro={onSkipIntro}
+            leadingPlayerNumber={leadingPlayerNumber}
           />
         </div>
       )}

--- a/src/routes/online/online-room.tsx
+++ b/src/routes/online/online-room.tsx
@@ -78,11 +78,16 @@ function OnlineRoom({ roomCode }: Props) {
     };
   }, []);
 
-  // Keep the mic monitored for the whole room stay so volume indicators work in the lobby
-  useMicMonitoring();
-
   const [status, statusDetail] = useOnlineConnectionStatus();
   const roomState = useOnlineRoomState();
+
+  // Everyone in the room keeps the mic monitored for the whole stay, re-asserted on every phase (and
+  // on connecting), so the volume bars are live at the same moments for the host and the singers
+  // alike. Screen-level monitoring can't do that here: the host's song-selection screen re-starts
+  // monitoring as it mounts, while a singer joining through an invite link ran the setup wizard
+  // inside the room and would stay on whatever input they had when the room first mounted.
+  useMicMonitoring(`${status}:${roomState?.phase ?? 'none'}`);
+
   const selfPlayerNumber = roomState?.participants.find(
     (participant) => participant.id === OnlineClient.getParticipantId(),
   )?.playerNumber;

--- a/src/routes/online/singing/online-singing.tsx
+++ b/src/routes/online/singing/online-singing.tsx
@@ -8,6 +8,7 @@ import useBlockScroll from '~/modules/hooks/use-block-scroll';
 import useFullscreen from '~/modules/hooks/use-fullscreen';
 import useKeyboard from '~/modules/hooks/use-keyboard';
 import useViewportSize from '~/modules/hooks/use-viewport-size';
+import { useOnlineLeaderboard } from '~/modules/online/client/hooks';
 import { trackOnlineDriftSeek, trackOnlineSongStarted } from '~/modules/online/client/online-analytics';
 import OnlineClient from '~/modules/online/client/online-client';
 import { ONLINE_DRIFT_THRESHOLD_MS } from '~/modules/online/protocol/consts';
@@ -59,6 +60,17 @@ function OnlineSinging({ roomState, song }: Props) {
   // The local singer plays under their room player number so chart/lyrics colors match the room
   const selfNumber = self?.playerNumber ?? 0;
   const isHost = roomState.hostId === selfId;
+
+  // The medal next to the score belongs to whoever leads the ROOM. This client only sings (and
+  // scores) for itself, so the local game's own derivation would hand every singer a medal — the
+  // room's leaderboard is the only place the other scores exist. Null on a tie, as locally.
+  const leaderboard = useOnlineLeaderboard();
+  const leadingPlayerNumber = useMemo(() => {
+    if (!leaderboard.length) return null;
+    const top = leaderboard.reduce((best, entry) => (entry.score > best.score ? entry : best));
+    const tied = leaderboard.some((entry) => entry.participantId !== top.participantId && entry.score === top.score);
+    return tied ? null : top.playerNumber;
+  }, [leaderboard]);
 
   const singSetup = useMemo<SingSetup>(
     () => ({
@@ -302,6 +314,7 @@ function OnlineSinging({ roomState, song }: Props) {
           singSetup={singSetup}
           // Skip intro is offered only to the host and applies to the whole room
           skipIntroEnabled={isHost}
+          leadingPlayerNumber={leadingPlayerNumber}
           onSkipIntro={(targetTimeSec) =>
             OnlineClient.send.playback.seek(Math.max(0, targetTimeSec * 1_000 - videoGapMs))
           }


### PR DESCRIPTION
Three fixes to how an online room reports and renders per-singer state.

## Volume meters for other singers were laggy (~1 update / 1.5s)

- `ONLINE_STATS_PUBLISH_MS` 1000 → 300, plus a new `ONLINE_STATS_REPORT_MS` (300) so the client reports at the rate the room re-broadcasts.
- `useReportPlayerStats` now samples the mic every 50ms and sends the **peak** of each 300ms window. The old code sent one instantaneous reading every 1500ms, which aliased the loud parts away on top of being slow.
- Traffic guard: a report is skipped while the level hasn't moved (< 0.0005), with a 1.5s keepalive that also refreshes ping. A silent singer now costs ~0.7 msg/s (was 0.67), a loud one 3.3 msg/s; payload is two numbers, six singers max.
- `VolumeIndicator` (remote variant only) tweens `transform` linearly over one publish interval, so ~3 updates/s read as a meter instead of a bar hopping between positions.

## Mic monitoring wasn't consistent between host and singers

Monitoring was effectively screen-driven: the host's song-selection screen re-calls `InputManager.startMonitoring()` whenever it mounts (`game-settings.tsx`), while a singer starts once when the room mounts. A singer joining through an invite link runs the setup wizard *inside* the room, so monitoring can begin before they've picked their mic and never re-assert.

- `useMicMonitoring` takes an optional `reassertOn` key; changing it re-runs `startMonitoring()` only. That call is idempotent per device (`MicInput` early-returns when already started), so it picks up inputs added since and never tears a live pipeline down. Mount/unmount ownership rules are unchanged.
- `OnlineRoom` passes `` `${status}:${phase}` ``, so every participant re-asserts on connection and on each room phase, regardless of which screen their role happens to render.

## The first-place medal was shown to every singer

Each client's `PlayersManager` holds only itself in a room, so `getPlayerScoreData` ranked a one-entry list — place 0, no tie — and crowned everyone.

- `GameOverlay`/`Player` take an optional `leadingPlayerNumber`. Undefined (local game) keeps the existing local derivation untouched; when set, the medal shows only for that player number.
- `OnlineSinging` derives it from the room leaderboard — the only place the other singers' scores exist — and returns `null` on a tie, matching the local ex-aequo rule. Everyone at 0 at song start = no medal; a solo room shows it, same as local solo play.

## Notes for the reviewer

- `room-logic.test.ts` now advances by `ONLINE_STATS_PUBLISH_MS` instead of a hardcoded `1_000`.
- `OnlineSinging` subscribes to the leaderboard (~2 renders/s of that subtree); it already re-renders on every room-state push, so this isn't a new class of work.
- Verified with typecheck, oxlint and the unit suite (222 passed). **Not** verified in a live room — that needs two clients plus the room server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Online singing now displays the room-wide leading player’s medal, with ties shown without a leader.
  * Microphone monitoring updates when connection status, room phase, or selected input changes.
* **Improvements**
  * Volume indicators animate more smoothly.
  * Online player volume and connection statistics update more responsively while reducing unnecessary updates.
  * Periodic connection keepalives improve ongoing room status reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->