### PR TITLE
Restrict the leaderboard to Medium and harder difficulties

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -32,16 +32,16 @@ copy until it expires.
 | --- | --- |
 | `worker/leaderboard-do.ts` | `LeaderboardBoard` — SQLite storage, projection, expiry alarm |
 | `worker/leaderboard.ts` | `POST` validation + `GET` cache/KV read path |
-| `worker/leaderboard-admin.ts` | Authenticated list + delete |
+| `worker/leaderboard-admin.ts` | Authenticated list, delete, and manual projection rebuild |
 | `src/modules/leaderboard/types.ts` | Shapes shared by client and Worker — must stay dependency-free |
-| `src/modules/leaderboard/consts.ts` | `QUALIFYING_SCORE` and the payload bounds, derived from `MAX_POINTS` |
+| `src/modules/leaderboard/consts.ts` | `QUALIFYING_SCORE`, `MAX_QUALIFYING_TOLERANCE` and the payload bounds |
 | `src/modules/leaderboard/notes-payload.ts` | Delta encoder/decoder for the frequency records |
 | `src/modules/leaderboard/notes-hash.ts` | sha-256 over `notes ++ score`, used on both sides |
 | `src/modules/leaderboard/identity.ts` | localStorage `clientId`, name and country |
 | `src/modules/leaderboard/sharing.ts` | The standing decision: undecided / always / never |
 | `src/routes/game/singing/post-game/views/leaderboard/` | The prompt, the high-scores panel, and the hook holding their shared state |
 | `src/routes/welcome/leaderboard-panel.tsx` | The board on the main menu |
-| `src/routes/admin/leaderboard-management.tsx` | Row deletion |
+| `src/routes/admin/leaderboard-management.tsx` | Row deletion and the rebuild button |
 
 The Worker imports from `src/` with **relative** paths. The `~` alias is only configured for the app
 build, so `~/modules/...` does not resolve inside the Worker bundle or its tests.
@@ -86,6 +86,12 @@ admin deletion is the remedy.
 Artist and title are denormalized so the board renders standalone: no song-index lookup on the
 client, and a removed song does not blank a row.
 
+The public projection selects only rows within the 14-day window whose `tolerance` is Medium or
+harder. It is rebuilt on every write and by the daily alarm, never on deploy — so a change to what
+it selects reaches the board on the next submission, or up to a day later. `POST /leaderboard-admin`
+(the admin panel's **Rebuild public board**) applies it immediately and purges the read cache. Submissions easier than that are already rejected, so the filter is there for rows stored
+before the rule and for the admin listing, which deliberately keeps showing everything.
+
 **Every** accepted submission is stored, not only the ones that currently rank. A "discard anything
 outside the top 50" rule cannot survive the 14-day expiry — discarded rows are unrecoverable, so the
 board would erode toward empty as leaders age out.
@@ -112,6 +118,7 @@ The alarm is scheduled the first time the object is constructed, so no Cron Trig
 - a body over 256 KB,
 - a body that is not msgpack, or is missing a required field,
 - a non-integer score, or one below `QUALIFYING_SCORE` or above `MAX_POINTS`,
+- a `tolerance` easier than `MAX_QUALIFYING_TOLERANCE` (only Medium and Hard count),
 - missing notes, malformed notes, or a record count outside the plausibility bounds,
 - a `notesHash` that does not match a server-side recomputation over `notes ++ score`,
 - a client over the rate limit.

--- a/src/modules/leaderboard/consts.ts
+++ b/src/modules/leaderboard/consts.ts
@@ -10,6 +10,14 @@ export const QUALIFYING_SCORE_RATIO = 2 / 7;
 
 export const QUALIFYING_SCORE = MAX_POINTS * QUALIFYING_SCORE_RATIO;
 
+/**
+ * Widest pitch tolerance (a sing setup's `tolerance`) the board accepts: 1 = Hard, 2 = Medium,
+ * 3 = Easy, 4+ the dev-only debug widths. Only Medium and harder count — every step widens the
+ * pitch window the scoring uses, so an Easy run reaches the qualifying score for singing that
+ * would not come close on Medium, and the rows would not be comparable.
+ */
+export const MAX_QUALIFYING_TOLERANCE = 2;
+
 /** Request body cap for `POST /leaderboard`. */
 export const MAX_SUBMISSION_BYTES = 256 * 1024;
 

--- a/src/modules/leaderboard/qualifies.ts
+++ b/src/modules/leaderboard/qualifies.ts
@@ -1,4 +1,4 @@
-import { QUALIFYING_SCORE } from '~/modules/leaderboard/consts';
+import { MAX_QUALIFYING_TOLERANCE, QUALIFYING_SCORE } from '~/modules/leaderboard/consts';
 import isE2E from '~/modules/utils/is-e2-e';
 
 /**
@@ -8,4 +8,10 @@ import isE2E from '~/modules/utils/is-e2-e';
  */
 export const getQualifyingScore = () => (isE2E() ? QUALIFYING_SCORE / 1000 : QUALIFYING_SCORE);
 
-export const qualifiesForLeaderboard = (score: number) => score >= getQualifyingScore();
+/**
+ * Difficulty is part of qualifying, not just the score: Easy (and the debug widths above it) widen
+ * the pitch window enough that its scores are not comparable, so nothing sung on them is offered to
+ * the board. The Worker enforces the same rule on submit — this only keeps the prompt away.
+ */
+export const qualifiesForLeaderboard = (score: number, tolerance: number) =>
+  score >= getQualifyingScore() && tolerance <= MAX_QUALIFYING_TOLERANCE;

--- a/src/routes/admin/leaderboard-admin-api.ts
+++ b/src/routes/admin/leaderboard-admin-api.ts
@@ -36,6 +36,18 @@ export const listAdminLeaderboardEntries = async (password: string) => {
   return payload.entries;
 };
 
+/**
+ * Re-runs the server-side projection over the stored rows. The board is rebuilt on every write, so
+ * this is only needed after a deploy that changes what the projection selects — without it the
+ * public board keeps its old contents until the next submission or the daily expiry alarm.
+ */
+export const rebuildAdminLeaderboardProjection = async (password: string) => {
+  const response = await fetch(LEADERBOARD_ADMIN_URL, { method: 'POST', headers: adminHeaders(password) });
+  await assertOk(response);
+
+  return (await response.json()) as { entries: number };
+};
+
 export const deleteAdminLeaderboardEntry = async (password: string, id: string) => {
   const url = new URL(LEADERBOARD_ADMIN_URL, window.location.origin);
   url.searchParams.set('id', id);

--- a/src/routes/admin/leaderboard-management.tsx
+++ b/src/routes/admin/leaderboard-management.tsx
@@ -1,4 +1,4 @@
-import { Alert, IconButton, Tooltip } from '@mui/material';
+import { Alert, Button, IconButton, Tooltip } from '@mui/material';
 import dayjs from 'dayjs';
 import { MaterialReactTable, type MRT_ColumnDef } from 'material-react-table';
 import { useMemo, useState } from 'react';
@@ -7,7 +7,11 @@ import useSWR from 'swr';
 import { Icon } from '~/modules/elements/akui/icon';
 import { AdminBoardEntry } from '~/modules/leaderboard/types';
 
-import { deleteAdminLeaderboardEntry, listAdminLeaderboardEntries } from './leaderboard-admin-api';
+import {
+  deleteAdminLeaderboardEntry,
+  listAdminLeaderboardEntries,
+  rebuildAdminLeaderboardProjection,
+} from './leaderboard-admin-api';
 
 interface Props {
   password: string;
@@ -33,6 +37,8 @@ const columns: MRT_ColumnDef<AdminBoardEntry>[] = [
  */
 export function LeaderboardManagement({ password }: Props) {
   const [error, setError] = useState<string | null>(null);
+  const [rebuilt, setRebuilt] = useState<number | null>(null);
+  const [isRebuilding, setIsRebuilding] = useState(false);
 
   const {
     data,
@@ -42,6 +48,25 @@ export function LeaderboardManagement({ password }: Props) {
   } = useSWR(['leaderboard-admin', password], () => listAdminLeaderboardEntries(password));
 
   const tableColumns = useMemo(() => columns, []);
+
+  /**
+   * Only useful after a deploy that changes what the projection selects — the public board is
+   * rebuilt on every write, so in normal operation there is nothing here to fix.
+   */
+  const rebuild = async () => {
+    setError(null);
+    setRebuilt(null);
+    setIsRebuilding(true);
+
+    try {
+      const { entries } = await rebuildAdminLeaderboardProjection(password);
+      setRebuilt(entries);
+    } catch (rebuildError) {
+      setError(rebuildError instanceof Error ? rebuildError.message : 'Failed to rebuild the board');
+    } finally {
+      setIsRebuilding(false);
+    }
+  };
 
   const remove = async (entry: AdminBoardEntry) => {
     // Deleting a board row cannot be undone, and the rows are one click apart in the table
@@ -63,6 +88,20 @@ export function LeaderboardManagement({ password }: Props) {
       {(error || listError) && (
         <Alert severity="error">{error ?? (listError instanceof Error ? listError.message : 'Failed to load')}</Alert>
       )}
+      {rebuilt !== null && (
+        <Alert severity="success">
+          Public board rebuilt — {rebuilt} {rebuilt === 1 ? 'row' : 'rows'} on it now.
+        </Alert>
+      )}
+      <div className="flex items-center gap-4">
+        <Button variant="outlined" onClick={rebuild} disabled={isRebuilding} data-test="rebuild-leaderboard-projection">
+          {isRebuilding ? 'Rebuilding…' : 'Rebuild public board'}
+        </Button>
+        <span className="text-sm opacity-70">
+          Re-runs the projection over the stored rows. Needed after a deploy that changes what the board shows — it
+          otherwise updates on the next submission or the daily expiry pass.
+        </span>
+      </div>
       <MaterialReactTable
         columns={tableColumns}
         data={data ?? []}

--- a/src/routes/game/singing/post-game/views/leaderboard/use-leaderboard-post-game.ts
+++ b/src/routes/game/singing/post-game/views/leaderboard/use-leaderboard-post-game.ts
@@ -41,7 +41,8 @@ export default function useLeaderboardPostGame({ song, singSetup }: Params) {
     return players.sort((first, second) => second.score - first.score)[0] ?? null;
   }, []);
 
-  const qualifies = !!leaderboardEnabled && !!topPlayer && qualifiesForLeaderboard(topPlayer.score);
+  const qualifies =
+    !!leaderboardEnabled && !!topPlayer && qualifiesForLeaderboard(topPlayer.score, singSetup.tolerance);
 
   /**
    * Derived, not seeded from the first render: `useLeaderboardEnabled` reads a PostHog flag that can

--- a/tests/leaderboard.spec.ts
+++ b/tests/leaderboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { enableLeaderboard, initTestMode, mockSongs } from './helpers';
 import initialise from './page-objects/initialise';
@@ -19,10 +19,10 @@ const playerCountry = 'Poland';
 /**
  * From the main menu through a full song, stopping on the post-game high scores step.
  *
- * Sung on Easy on purpose: the stubbed microphone scores around 890k on the default difficulty,
- * just under the 1,000,000 the Worker requires, so the submission would be rejected server-side.
+ * Sung on the default Medium: the board refuses anything easier (see MAX_QUALIFYING_TOLERANCE), so
+ * Easy - where the stubbed microphone scores highest - is not an option for a submitting run.
  */
-const singTheSong = async (page: Page) => {
+const singTheSong = async () => {
   await pages.mainMenuPage.goToInputSelectionPage();
   await pages.inputSelectionPage.selectAdvancedSetup();
   await pages.advancedConnectionPage.goToMainMenu();
@@ -35,9 +35,7 @@ const singTheSong = async (page: Page) => {
   await pages.songListPage.approveSelectedSongByKeyboard();
 
   await pages.songPreviewPage.navigateToDifficultySettingsWithKeyboard();
-  await page.keyboard.press('Enter'); // Hard
-  await page.keyboard.press('Enter'); // Easy
-  await pages.songPreviewPage.expectGameDifficultyLevelToBe('Easy');
+  await pages.songPreviewPage.expectGameDifficultyLevelToBe('Medium');
   await pages.songPreviewPage.navigateToGoNextWithKeyboard();
 
   await pages.songPreviewPage.navigateToPlayTheSongWithKeyboard();
@@ -77,7 +75,7 @@ test.describe('Global leaderboard enabled', () => {
       await expect(pages.leaderboardPage.panel).toBeVisible();
     });
 
-    await singTheSong(page);
+    await singTheSong();
 
     await test.step('The prompt opens on the high scores step', async () => {
       await expect(pages.leaderboardPage.prompt).toBeVisible();
@@ -98,7 +96,7 @@ test.describe('Global leaderboard enabled', () => {
       await pages.landingPage.enterTheGame();
 
       await expect(pages.leaderboardPage.rowFor(playerName).first()).toBeVisible({ timeout: 30_000 });
-      await pages.leaderboardPage.expectRowFor(playerName, 'E2ETest', 'Easy');
+      await pages.leaderboardPage.expectRowFor(playerName, 'E2ETest', 'Medium');
     });
   });
 
@@ -108,7 +106,7 @@ test.describe('Global leaderboard enabled', () => {
     await pages.landingPage.enterTheGame();
 
     await test.step('Opt into sharing every score from the prompt', async () => {
-      await singTheSong(page);
+      await singTheSong();
       await expect(pages.leaderboardPage.prompt).toBeVisible();
       await pages.leaderboardPage.fillIdentity(alwaysPlayerName, playerCountry);
       await pages.leaderboardPage.submit();
@@ -137,7 +135,7 @@ test.describe('Global leaderboard enabled', () => {
     test.slow();
     await page.goto('/?e2e-test');
     await pages.landingPage.enterTheGame();
-    await singTheSong(page);
+    await singTheSong();
 
     await expect(pages.leaderboardPage.prompt).toBeVisible();
     await pages.leaderboardPage.declineButton.click();
@@ -166,7 +164,7 @@ test.describe('Global leaderboard disabled', () => {
     await expect(pages.mainMenuPage.singSongButton).toBeVisible();
     await expect(page.getByTestId('leaderboard-panel')).toHaveCount(0);
 
-    await singTheSong(page);
+    await singTheSong();
 
     await expect(pages.postGameHighScoresPage.highScoresContainer).toBeVisible();
     await expect(pages.leaderboardPage.prompt).toHaveCount(0);

--- a/worker/leaderboard-admin.ts
+++ b/worker/leaderboard-admin.ts
@@ -10,8 +10,8 @@ export interface LeaderboardAdminEnv extends LeaderboardEnv {
 }
 
 /**
- * Authenticated list + delete. Row ids only ever reach the admin UI through here — the public board
- * never carries them.
+ * Authenticated list, delete, and a manual projection rebuild. Row ids only ever reach the admin UI
+ * through here — the public board never carries them.
  */
 export const handleLeaderboardAdmin = async (request: Request, env: LeaderboardAdminEnv) => {
   if (!isAuthorizedUnverifiedSongsAdmin(request, env)) return unauthorizedResponse();
@@ -26,6 +26,15 @@ export const handleLeaderboardAdmin = async (request: Request, env: LeaderboardA
 
   if (request.method === 'GET') {
     return new Response(JSON.stringify({ entries: await board.listForAdmin() }), { headers: responseHeaders });
+  }
+
+  if (request.method === 'POST') {
+    const result = await board.rebuild();
+
+    // Same reasoning as the delete path: the point of rebuilding by hand is seeing the result now
+    await caches.default.delete(boardCacheKey(request));
+
+    return new Response(JSON.stringify(result), { headers: responseHeaders });
   }
 
   if (request.method === 'DELETE') {

--- a/worker/leaderboard-do.test.ts
+++ b/worker/leaderboard-do.test.ts
@@ -58,6 +58,25 @@ describe('LeaderboardBoard', () => {
     expect(entry).not.toHaveProperty('id');
   });
 
+  it('keeps a row sung on Easy off the board, admin listing aside', async () => {
+    const board = getBoard();
+
+    await board.submit(generateSubmission({ clientId: 'client-easy', tolerance: 3, score: 3_000_000 }), notesBlob);
+    await board.submit(generateSubmission({ clientId: 'client-medium' }), notesBlob);
+
+    expect((await board.projection()).entries).toEqual([expect.objectContaining({ score: 1_500_000, tolerance: 2 })]);
+    expect(await board.listForAdmin()).toHaveLength(2);
+  });
+
+  it('rebuilds the projection over the stored rows on demand', async () => {
+    const board = getBoard();
+    await board.submit(generateSubmission(), notesBlob);
+
+    // The write path already rebuilt it; the point is that asking again is safe and reports the board
+    expect(await board.rebuild()).toEqual({ entries: 1 });
+    expect(JSON.parse((await workerEnv.LEADERBOARD_KV!.get(BOARD_KV_KEY))!).entries).toHaveLength(1);
+  });
+
   it('keeps the higher score for a repeated client, song and name', async () => {
     const board = getBoard();
 

--- a/worker/leaderboard-do.ts
+++ b/worker/leaderboard-do.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 
 // Relative import on purpose: the `~` alias is only configured for the app build, not the Worker one
+import { MAX_QUALIFYING_TOLERANCE } from '../src/modules/leaderboard/consts';
 import {
   AdminBoardEntry,
   BOARD_KV_KEY,
@@ -185,13 +186,19 @@ export class LeaderboardBoard extends DurableObject<LeaderboardDurableObjectEnv>
     return { accepted: true };
   }
 
-  /** Top {@link BOARD_SIZE} rows of the retention window, in public shape. Never selects `notes`. */
+  /**
+   * Top {@link BOARD_SIZE} rows of the retention window, in public shape. Never selects `notes`.
+   *
+   * The difficulty filter is not only about rows submitted before the rule existed — the admin
+   * listing still shows everything, so the board is where "Medium or harder" has to hold.
+   */
   projection(): BoardResponse {
     const rows = this.sql
       .exec<RecordRow>(
         `SELECT id, name, country, score, artist, title, song_id, tolerance, created_at
-         FROM records WHERE created_at >= ? ORDER BY score DESC, created_at ASC LIMIT ?`,
+         FROM records WHERE created_at >= ? AND tolerance <= ? ORDER BY score DESC, created_at ASC LIMIT ?`,
         Date.now() - RETENTION_MS,
+        MAX_QUALIFYING_TOLERANCE,
         BOARD_SIZE,
       )
       .toArray();
@@ -221,6 +228,18 @@ export class LeaderboardBoard extends DurableObject<LeaderboardDurableObjectEnv>
     await this.rebuildProjection();
 
     return true;
+  }
+
+  /**
+   * Rebuilds the KV projection from the rows as they stand. Nothing else needs this — every write
+   * path rebuilds on its own — but a change to what `projection()` selects (a new filter, a new
+   * board size) only reaches the public board on the next write or the daily alarm, and this is
+   * the way to apply it on deploy instead of waiting a day.
+   */
+  async rebuild(): Promise<{ entries: number }> {
+    await this.rebuildProjection();
+
+    return { entries: this.projection().entries.length };
   }
 
   async alarm() {

--- a/worker/leaderboard.test.ts
+++ b/worker/leaderboard.test.ts
@@ -102,6 +102,20 @@ describe('POST /leaderboard', () => {
     expect(await response.json()).toEqual({ error: 'Score out of range' });
   });
 
+  it('rejects a score sung on Easy', async () => {
+    const response = await submit(await generateSubmission({ tolerance: 3 }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Difficulty not eligible' });
+  });
+
+  it('accepts a score sung on Hard', async () => {
+    const response = await submit(await generateSubmission({ tolerance: 1 }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ accepted: true });
+  });
+
   it('rejects a non-integer score', async () => {
     const response = await submit(await generateSubmission({ score: 1_500_000.5 }));
 
@@ -241,5 +255,26 @@ describe('/leaderboard-admin', () => {
     // Deletion is the moderation path, so the row must leave the cached board immediately
     const board = await SELF.fetch('https://example.com/leaderboard');
     expect(((await board.json()) as BoardResponse).entries).toHaveLength(0);
+  });
+
+  it('rebuilds the public board on POST and serves the result straight away', async () => {
+    await submit(await generateSubmission());
+
+    const response = await SELF.fetch('https://example.com/leaderboard-admin', {
+      method: 'POST',
+      headers: adminHeaders,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ entries: 1 });
+
+    const board = await SELF.fetch('https://example.com/leaderboard');
+    expect(((await board.json()) as BoardResponse).entries).toHaveLength(1);
+  });
+
+  it('refuses an unauthenticated rebuild', async () => {
+    const response = await SELF.fetch('https://example.com/leaderboard-admin', { method: 'POST' });
+
+    expect(response.status).toBe(401);
   });
 });

--- a/worker/leaderboard.ts
+++ b/worker/leaderboard.ts
@@ -4,6 +4,7 @@ import { unpack } from 'msgpackr';
 import {
   MAX_NOTES_RECORDS,
   MAX_POINTS,
+  MAX_QUALIFYING_TOLERANCE,
   MAX_SUBMISSION_BYTES,
   MAX_SUBMITTED_ID_LENGTH,
   MAX_SUBMITTED_NAME_LENGTH,
@@ -95,6 +96,17 @@ const validateSubmission = (payload: unknown): { submission: LeaderboardSubmissi
   if (!Number.isInteger(submission.score)) return { message: 'Invalid score' };
   if (submission.score! < QUALIFYING_SCORE || submission.score! > MAX_POINTS) {
     return { message: 'Score out of range' };
+  }
+
+  // The board only ranks Medium and harder — a wider pitch window is not the same game, and the
+  // client already refuses to offer those scores. Checked here too because the client is not the
+  // authority on what reaches a public board.
+  if (
+    !Number.isInteger(submission.tolerance) ||
+    submission.tolerance! < 1 ||
+    submission.tolerance! > MAX_QUALIFYING_TOLERANCE
+  ) {
+    return { message: 'Difficulty not eligible' };
   }
 
   if (!(submission.notes instanceof Uint8Array) || submission.notes.byteLength === 0) {


### PR DESCRIPTION
## What

The global leaderboard now only takes scores sung on **Medium or harder** (`tolerance <= 2`; 1 = Hard, 2 = Medium, 3 = Easy, 4+ dev-only debug widths).

- `MAX_QUALIFYING_TOLERANCE` in `src/modules/leaderboard/consts.ts`, shared by app and Worker.
- `qualifiesForLeaderboard(score, tolerance)` — the post-game prompt/panel no longer offers a score sung on Easy.
- `POST /leaderboard` rejects an ineligible `tolerance` with `400 Difficulty not eligible`.
- The public projection query filters on `tolerance` as well, so rows stored before the rule drop off the board. `listForAdmin` is untouched — the admin listing still shows everything.

## Why

Every difficulty step widens the pitch window the scoring uses. An Easy run reaches the 1,000,000 qualifying score on singing that would not come close on Medium, so those rows are not comparable with the rest of the board.

The Worker check is not redundant with the client one: the client is not the authority on what reaches a public board.

## Also: a rebuild button in the admin panel

The projection is rebuilt on every accepted write and by the daily expiry alarm — never on deploy, and `GET /leaderboard` never touches the Durable Object. So this change would otherwise only reach the public board on the next submission, or up to a day later.

`POST /leaderboard-admin` (same auth as list/delete) re-runs the projection and purges the read cache, surfaced as **Rebuild public board** in the admin panel. Useful for this deploy and any later change to what the board selects.

## Notes for the reviewer

- **The e2e spec's premise was stale.** `tests/leaderboard.spec.ts` sang on Easy on purpose, with a comment that the stubbed mic only reaches ~890k on Medium — under the Worker's 1,000,000 gate. It actually scores ~1.27M there, so the spec now sings the default Medium and asserts the row reads `Medium`. All 4 tests pass against a production build.
- **Existing Easy rows** disappear as soon as the rebuild button is pressed after deploy (they would also have aged out on their own within the 14-day retention window).
- The visual-regression leaderboard spec already sings the default Medium and is unaffected.

## Testing

- 3 new Worker/DO tests: Easy rejected, Hard accepted, Easy row excluded from the projection but present in the admin listing; plus rebuild endpoint (authed 200 + serves the fresh board, unauthenticated 401) and `rebuild()` writing KV.
- Full unit suite: 284 passed.
- `tests/leaderboard.spec.ts` on a prod build: 4 passed.
- Rebuild endpoint exercised against the local dev Worker — 401 unauthenticated, `{"entries":2}` authed, `GET /leaderboard` then served the rebuilt board.

I did not click the button in a browser: it sits behind the admin password form, and I don't enter passwords into fields. The endpoint underneath is covered by the tests and the manual check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Leaderboard eligibility now requires Medium difficulty or harder.
  - Administrators can manually rebuild the public leaderboard and see the resulting entry count.
  - Rebuilt leaderboard results are available immediately after changes.

- **Bug Fixes**
  - Easier-difficulty submissions are now rejected consistently and excluded from public rankings.
  - Leaderboard caches are refreshed after manual rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->